### PR TITLE
docs: update example to disable ExternalSharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The schema of the `config/browserforce-shape-def.json` is similar to `config/pro
 
 ```json
 "orgPreferences": {
-    "enabled": [
+    "disabled": [
       "ExternalSharing"
     ]
 }


### PR DESCRIPTION
In scratch orgs `ExternalSharing` is enabled by default,
so it makes sense to show how to disable it.

[ci skip]