### PR TITLE
chore(CI): temporary use MacOS in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os:
+  - osx
 language: node_js
 node_js:
   - "10"


### PR DESCRIPTION
[Travis CI fails to create a scratch org](https://salesforce.stackexchange.com/questions/210794/travis-ci-fails-to-create-a-scratch-org)