### PR TITLE
feat: sfdx-browserforce-plugin binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0-development",
   "description": "sfdx plugin for executing various tasks using browser automation",
   "author": "Matthias Rolke <mr.amtrack@gmail.com>",
+  "bin": {
+    "sfdx-browserforce-plugin": "bin/run"
+  },
   "dependencies": {
     "@oclif/command": "^1",
     "@oclif/config": "^1",
@@ -25,12 +28,13 @@
     "mocha": "^5",
     "nyc": "^13",
     "ts-node": "^7",
-    "typescript": "^3.1"
+    "typescript": "^3.1.5"
   },
   "engines": {
     "node": ">=8.0.0"
   },
   "files": [
+    "/bin",
     "/lib",
     "/messages",
     "/oclif.manifest.json",
@@ -43,6 +47,7 @@
   ],
   "license": "MIT",
   "oclif": {
+    "bin": "sfdx-browserforce-plugin",
     "commands": "./lib/commands",
     "topics": {
       "browserforce": {
@@ -61,6 +66,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepare": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "test:e2e": "mocha --forbid-only \"test/**/*.e2e-spec.ts\" \"src/**/*.e2e-spec.ts\"",
     "version": "oclif-dev readme && git add README.md"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3234,10 +3234,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.4.tgz#c74ef7b3c2da65beff548b903022cb8c3cd997ed"
-  integrity sha512-JZHJtA6ZL15+Q3Dqkbh8iCUmvxD3iJ7ujXS+fVkKnwIVAdHc5BJTDNM0aTrnr2luKulFjU7W+SRhDZvi66Ru7Q==
+typescript@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.5.tgz#93d8b6864375325a91177372cb370ae0ae3a0703"
+  integrity sha512-muYNWV9j5+3mXoKD6oPONKuGUmYiFX14gfo9lWm9ZXRHOqVDQiB4q1CzFPbF4QLV2E9TZXH6oK55oQ94rn3PpA==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
This makes it possible to declare `sfdx-browserforce-plugin`
as a dependency in a Node.js project
to prevent installing it globally with sfdx.

```console
npm install --save-dev sfdx-browserforce-plugin
```

You can then use the binary using `npx`

```console
npx sfdx-browserforce-plugin browserforce:shape:apply ...
```

or inside _npm scripts_ (`package.json`)

```json
{
  "scripts": {
    "dev:org": "sfdx force:org create ...",
    "dev:browserforce": "sfdx-browserforce-plugin browserforce:shape:apply ...",
    "dev": "npm run dev:org && npm run dev:browserforce"
  }
}
```