### PR TITLE
fix: try to make setting checkboxes less flaky

### DIFF
--- a/src/plugins/admins-can-log-in-as-any/index.ts
+++ b/src/plugins/admins-can-log-in-as-any/index.ts
@@ -44,14 +44,12 @@ export default class AdminsCanLogInAsAny extends ShapePlugin {
     const page = await this.getPage();
     await page.goto(this.getBaseUrl());
     await page.waitFor(this.constructor['schema'].properties.enabled.selector);
-    await page.evaluate(
-      data => {
-        const checkbox = document.querySelector(data.action.selector);
-        checkbox.checked = data.action.targetValue;
+    await page.$eval(
+      action.selector,
+      (e: HTMLInputElement, v) => {
+        e.checked = v;
       },
-      {
-        action
-      }
+      action.targetValue
     );
     await Promise.all([
       page.waitFor(this.constructor['SELECTORS'].CONFIRM_MESSAGE),

--- a/src/plugins/customer-portal/index.ts
+++ b/src/plugins/customer-portal/index.ts
@@ -58,14 +58,12 @@ export default class CustomerPortal extends ShapePlugin {
     const page = await this.getPage();
     await page.goto(this.getBaseUrl());
     await page.waitFor(this.constructor['schema'].properties.enabled.selector);
-    await page.evaluate(
-      data => {
-        const checkbox = document.querySelector(data.action.selector);
-        checkbox.checked = data.action.targetValue;
+    await page.$eval(
+      action.selector,
+      (e: HTMLInputElement, v) => {
+        e.checked = v;
       },
-      {
-        action
-      }
+      action.targetValue
     );
     await Promise.all([
       page.waitForNavigation(),

--- a/src/plugins/salesforce-to-salesforce/index.ts
+++ b/src/plugins/salesforce-to-salesforce/index.ts
@@ -56,14 +56,12 @@ export default class SalesforceToSalesforce extends ShapePlugin {
     const page = await this.getPage();
     await page.goto(this.getBaseUrl());
     await page.waitFor(this.constructor['schema'].properties.enabled.selector);
-    await page.evaluate(
-      data => {
-        const checkbox = document.querySelector(data.action.selector);
-        checkbox.checked = data.action.targetValue;
+    await page.$eval(
+      action.selector,
+      (e: HTMLInputElement, v) => {
+        e.checked = v;
       },
-      {
-        action
-      }
+      action.targetValue
     );
     await Promise.all([
       page.waitForNavigation(),


### PR DESCRIPTION
The SalesforceToSalesforce tests failed from time to time in CI.

Use `page.$eval` as seen here:
https://github.com/adonisjs/vow-browser/blob/59c5a20a2f04db4dda315efe916dbf9385bd26d9/src/Browser/ActionsChain.js#L134