### PR TITLE
fix: exiting the process

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@oclif/config": "^1",
     "@oclif/errors": "^1",
     "@salesforce/command": "^0.2.5",
-    "bluebird": "^3.5.2",
     "puppeteer": "^1.10.0",
     "tslib": "^1"
   },

--- a/src/plugins/admins-can-log-in-as-any/index.e2e-spec.ts
+++ b/src/plugins/admins-can-log-in-as-any/index.e2e-spec.ts
@@ -12,8 +12,8 @@ describe(AdminsCanLogInAsAny.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'enable.json'))
     ]);
-    assert.deepEqual(enableCmd.status, 0, enableCmd.stderr);
-    assert(/to 'true'/.test(enableCmd.stderr.toString()));
+    assert.deepEqual(enableCmd.status, 0, enableCmd.output.toString());
+    assert(/to 'true'/.test(enableCmd.output.toString()));
   });
   it('should disable', function() {
     this.timeout(1000 * 60);
@@ -23,7 +23,7 @@ describe(AdminsCanLogInAsAny.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'disable.json'))
     ]);
-    assert.deepEqual(disableCmd.status, 0, disableCmd.stderr);
-    assert(/to 'false'/.test(disableCmd.stderr.toString()));
+    assert.deepEqual(disableCmd.status, 0, disableCmd.output.toString());
+    assert(/to 'false'/.test(disableCmd.output.toString()));
   });
 });

--- a/src/plugins/customer-portal/index.e2e-spec.ts
+++ b/src/plugins/customer-portal/index.e2e-spec.ts
@@ -12,8 +12,8 @@ describe(CustomerPortal.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'enable.json'))
     ]);
-    assert.deepEqual(enableCmd.status, 0, enableCmd.stderr);
-    assert(/to 'true'/.test(enableCmd.stderr.toString()));
+    assert.deepEqual(enableCmd.status, 0, enableCmd.output.toString());
+    assert(/to 'true'/.test(enableCmd.output.toString()));
   });
   it('should fail to disable', function() {
     this.timeout(1000 * 60);
@@ -23,8 +23,8 @@ describe(CustomerPortal.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'disable.json'))
     ]);
-    assert.deepEqual(disableCmd.status, 0, disableCmd.stderr);
-    assert(/to 'false'/.test(disableCmd.stderr.toString()));
-    assert(/cannot be disabled/.test(disableCmd.stderr.toString()));
+    assert.deepEqual(disableCmd.status, 1, disableCmd.output.toString());
+    assert(/to 'false'/.test(disableCmd.output.toString()));
+    assert(/cannot be disabled/.test(disableCmd.output.toString()));
   });
 });

--- a/src/plugins/external-sharing/index.e2e-spec.ts
+++ b/src/plugins/external-sharing/index.e2e-spec.ts
@@ -12,8 +12,8 @@ describe(ExternalSharing.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'enable.json'))
     ]);
-    assert.deepEqual(enableCmd.status, 0, enableCmd.stderr);
-    assert(/to 'true'/.test(enableCmd.stderr.toString()));
+    assert.deepEqual(enableCmd.status, 0, enableCmd.output.toString());
+    assert(/to 'true'/.test(enableCmd.output.toString()));
   });
   it('should disable', function() {
     this.timeout(1000 * 60);
@@ -23,7 +23,7 @@ describe(ExternalSharing.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'disable.json'))
     ]);
-    assert.deepEqual(disableCmd.status, 0, disableCmd.stderr);
-    assert(/to 'false'/.test(disableCmd.stderr.toString()));
+    assert.deepEqual(disableCmd.status, 0, disableCmd.output.toString());
+    assert(/to 'false'/.test(disableCmd.output.toString()));
   });
 });

--- a/src/plugins/salesforce-to-salesforce/index.e2e-spec.ts
+++ b/src/plugins/salesforce-to-salesforce/index.e2e-spec.ts
@@ -12,8 +12,8 @@ describe(SalesforceToSalesforce.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'enable.json'))
     ]);
-    assert.deepEqual(enableCmd.status, 0, enableCmd.stderr);
-    assert(/to 'true'/.test(enableCmd.stderr.toString()));
+    assert.deepEqual(enableCmd.status, 0, enableCmd.output.toString());
+    assert(/to 'true'/.test(enableCmd.output.toString()));
   });
   it('should fail to disable', function() {
     this.timeout(1000 * 60);
@@ -23,8 +23,8 @@ describe(SalesforceToSalesforce.name, () => {
       '-f',
       path.resolve(path.join(__dirname, 'disable.json'))
     ]);
-    assert.deepEqual(disableCmd.status, 0, disableCmd.stderr);
-    assert(/to 'false'/.test(disableCmd.stderr.toString()));
-    assert(/cannot be disabled/.test(disableCmd.stderr.toString()));
+    assert.deepEqual(disableCmd.status, 1, disableCmd.output.toString());
+    assert(/to 'false'/.test(disableCmd.output.toString()));
+    assert(/cannot be disabled/.test(disableCmd.output.toString()));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,11 +525,6 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bluebird@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
-  integrity sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This prevents the process from hanging on exit.
The exit code 1 is being returned on error.

By switching from bluebird promise to async/await,
the dependency bluebird is now removed.