### PR TITLE
fix: workaround for timeouts and redirect issues on frontdoor

### DIFF
--- a/src/browserforce.ts
+++ b/src/browserforce.ts
@@ -1,17 +1,26 @@
 import { core } from '@salesforce/command';
 import * as puppeteer from 'puppeteer';
+import { URL } from 'url';
+import { retry } from './plugins/utils';
+
+class FrontdoorRedirectError extends Error {}
+class LoginError extends Error {}
+class RetryableError extends Error {}
 
 const PERSONAL_INFORMATION_PATH =
   'setup/personalInformationSetup.apexp?nooverride=1';
 
 const ERROR_DIV_SELECTOR = '#errorTitle';
+const ERROR_DIVS_SELECTOR = 'div.errorMsg';
 
 export default class Browserforce {
   public org: core.Org;
+  public logger: core.Logger;
   public browser: puppeteer.Browser;
   public page: puppeteer.Page;
-  constructor(org) {
+  constructor(org, logger?) {
     this.org = org;
+    this.logger = logger;
   }
 
   public async login() {
@@ -19,53 +28,154 @@ export default class Browserforce {
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
       headless: !(process.env.BROWSER_DEBUG === 'true')
     });
-    this.page = await this.browser.newPage();
-    this.page.setDefaultNavigationTimeout(
-      parseInt(process.env.BROWSERFORCE_NAVIGATION_TIMEOUT_MS, 10) || 90000
-    );
-    await this.page.setViewport({ width: 1024, height: 768 });
-    const instanceUrl = this.getInstanceUrl();
-    const response = await this.page.goto(
-      `${instanceUrl}/secur/frontdoor.jsp?sid=${
+    await this.retryLogin(
+      `secur/frontdoor.jsp?sid=${
         this.org.getConnection().accessToken
-      }&retURL=${encodeURIComponent(PERSONAL_INFORMATION_PATH)}`,
-      { waitUntil: ['load', 'domcontentloaded', 'networkidle0'] }
+      }&retURL=${encodeURIComponent(PERSONAL_INFORMATION_PATH)}`
     );
-    if (response) {
-      if (response.status() === 500) {
-        const errorHandle = await this.page.$(ERROR_DIV_SELECTOR);
-        if (errorHandle) {
-          const errorMsg = this.page.evaluate(
-            div => div.innerText,
-            errorHandle
-          );
-          throw new Error(`login failed [500]: ${errorMsg}`);
-        } else {
-          throw new Error(`login failed [500]: ${response.statusText()}`);
-        }
-      }
-      if (response.url().indexOf('/?ec=302') > 0) {
-        throw new Error(
-          `login failed [302]: {"instanceUrl": "${instanceUrl}, "url": "${response
-            .url()
-            .split('/')
-            .slice(0, 3)
-            .join('/')}"}"`
-        );
-      }
-    } else {
-      throw new Error('login failed');
-    }
     return this;
   }
 
   public async logout() {
-    await this.page.close();
     await this.browser.close();
     return this;
   }
 
+  public async resolveDomains() {
+    // resolve ip addresses of both LEX and classic domains
+    for (const url of [this.getInstanceUrl(), this.getLightningUrl()]) {
+      const resolver = await core.MyDomainResolver.create({
+        url: new URL(url)
+      });
+      await resolver.resolve();
+    }
+  }
+
+  public async throwResponseErrors(response) {
+    if (!response) {
+      throw new Error('no response');
+    }
+    if (!response.ok()) {
+      throw new RetryableError(`${response.status()}: ${response.statusText()}`);
+    }
+    if (response.url().indexOf('/?ec=302') > 0) {
+      if (
+        !response.url().startsWith(this.getInstanceUrl()) &&
+        !response.url().startsWith(this.getLightningUrl())
+      ) {
+        const redactedUrl = response
+          .url()
+          .replace(/sid=(.*)/, 'sid=<REDACTED>')
+          .replace(/sid%3D(.*)/, 'sid=<REDACTED>');
+        throw new FrontdoorRedirectError(
+          `expected instance or lightning URL but got: ${redactedUrl}`
+        );
+      }
+      throw new LoginError('login failed');
+    }
+  }
+
+  public async throwPageErrors(page) {
+    const errorHandle = await page.$(ERROR_DIV_SELECTOR);
+    if (errorHandle) {
+      const errorMsg = await page.evaluate(
+        (div: HTMLDivElement) => div.innerText,
+        errorHandle
+      );
+      await errorHandle.dispose();
+      if (errorMsg && errorMsg.trim()) {
+        throw new Error(errorMsg.trim());
+      }
+    }
+    const errorElements = await page.$$(ERROR_DIVS_SELECTOR);
+    if (errorElements.length) {
+      const errorMessages = await page.evaluate((...errorDivs) => {
+        return errorDivs.map((div: HTMLDivElement) => div.innerText);
+      }, ...errorElements);
+      const errorMsg = errorMessages
+        .map(m => m.trim())
+        .join(' ')
+        .trim();
+      if (errorMsg) {
+        throw new Error(errorMsg);
+      }
+    }
+  }
+
+  // path instead of url
+  public async openPage(urlPath, options?) {
+    return await retry(
+      async () => {
+        try {
+          await this.resolveDomains();
+        } catch (error) {
+          throw new RetryableError(error);
+        }
+        const page = await this.browser.newPage();
+        page.setDefaultNavigationTimeout(
+          parseInt(process.env.BROWSERFORCE_NAVIGATION_TIMEOUT_MS, 10) || 90000
+        );
+        await page.setViewport({ width: 1024, height: 768 });
+        const url = `${this.getInstanceUrl()}/${urlPath}`;
+        const response = await page.goto(url, options);
+        await this.throwResponseErrors(response);
+        // await this.throwPageErrors(page);
+        return page;
+      },
+      5,
+      4000,
+      true,
+      RetryableError.prototype,
+      this.logger
+    );
+  }
+
   public getInstanceUrl() {
     return this.org.getConnection().instanceUrl;
+  }
+
+  private getLightningUrl() {
+    const myDomain = this.getInstanceUrl().match(/https?\:\/\/([^.]*)/)[1];
+    return `https://${myDomain}.lightning.force.com`;
+  }
+
+  private async retryLogin(
+    loginUrl,
+    refreshAuthLeft = 1,
+    frontdoorWorkaroundLeft = 1
+  ) {
+    try {
+      await this.openPage(loginUrl, {
+        waitUntil: ['load', 'domcontentloaded', 'networkidle0']
+      });
+    } catch (err) {
+      if (err instanceof LoginError && refreshAuthLeft > 0) {
+        if (this.logger) {
+          this.logger.warn(`retrying with refreshed auth because of "${err}"`);
+        }
+        await this.org.refreshAuth();
+        await this.retryLogin(
+          loginUrl,
+          refreshAuthLeft - 1,
+          frontdoorWorkaroundLeft
+        );
+      } else if (
+        err instanceof FrontdoorRedirectError &&
+        frontdoorWorkaroundLeft > 0
+      ) {
+        if (this.logger) {
+          this.logger.warn(
+            `retrying open page with instance url because of "${err}"`
+          );
+        }
+        await this.retryLogin(
+          PERSONAL_INFORMATION_PATH,
+          refreshAuthLeft,
+          frontdoorWorkaroundLeft - 1
+        );
+      } else {
+        throw err;
+      }
+    }
   }
 }

--- a/src/browserforceCommand.ts
+++ b/src/browserforceCommand.ts
@@ -41,7 +41,7 @@ export default class BrowserforceCommand extends SfdxCommand {
     );
     // TODO: use require.resolve to dynamically load plugins from npm packages
     this.settings = ConfigParser.parse(DRIVERS, definition);
-    this.bf = new Browserforce(this.org);
+    this.bf = new Browserforce(this.org, this.ux.cli);
     this.ux.startSpinner('logging in');
     await this.bf.login();
     this.ux.stopSpinner();

--- a/src/plugins/customer-portal/availableCustomObjects/index.ts
+++ b/src/plugins/customer-portal/availableCustomObjects/index.ts
@@ -16,7 +16,6 @@ interface CustomObjectRecord {
 
 export default class CustomerPortalAvailableCustomObjects extends BrowserforcePlugin {
   public async retrieve(definition?) {
-    const page = this.browserforce.page;
     const response = [];
     if (definition) {
       const availableCustomObjectList = definition
@@ -33,7 +32,7 @@ export default class CustomerPortalAvailableCustomObjects extends BrowserforcePl
       // BUG in jsforce: query acts with scanAll:true and returns deleted CustomObjects.
       // It cannot be disabled.
       // This will throw a timeout error waitingFor('#options_9')
-      await page.goto(this.browserforce.getInstanceUrl(), {
+      const page = await this.browserforce.openPage('', {
         waitUntil: ['load', 'domcontentloaded', 'networkidle0']
       });
       // new URLs for LEX: https://help.salesforce.com/articleView?id=FAQ-for-the-New-URL-Format-for-Lightning-Experience-and-the-Salesforce-Mobile-App&type=1
@@ -59,17 +58,20 @@ export default class CustomerPortalAvailableCustomObjects extends BrowserforcePl
         }
         const classicUiPath = `${customObject.Id}/e`;
         if (isLEX) {
-          const availableForCustomerPortalUrl = `${this.browserforce.getInstanceUrl()}/lightning/setup/ObjectManager/${
+          const availableForCustomerPortalPath = `lightning/setup/ObjectManager/${
             customObject.Id
           }/edit?nodeId=ObjectManager&address=${encodeURIComponent(
             `/${classicUiPath}`
           )}`;
-          await page.goto(availableForCustomerPortalUrl, {
-            waitUntil: ['load', 'domcontentloaded', 'networkidle0']
-          });
+          const lexPage = await this.browserforce.openPage(
+            availableForCustomerPortalPath,
+            {
+              waitUntil: ['load', 'domcontentloaded', 'networkidle0']
+            }
+          );
           // maybe use waitForFrame https://github.com/GoogleChrome/puppeteer/issues/1361
-          await page.waitFor(SELECTORS.IFRAME);
-          const frame = await page
+          await lexPage.waitFor(SELECTORS.IFRAME);
+          const frame = await lexPage
             .frames()
             .find(f => f.name().startsWith('vfFrameId'));
           await frame.waitFor(
@@ -85,16 +87,15 @@ export default class CustomerPortalAvailableCustomObjects extends BrowserforcePl
             )
           });
         } else {
-          const availableForCustomerPortalUrl = `${this.browserforce.getInstanceUrl()}/${classicUiPath}`;
-          await page.goto(availableForCustomerPortalUrl);
-          await page.waitFor(
+          const classicPage = await this.browserforce.openPage(classicUiPath);
+          await classicPage.waitFor(
             SELECTORS.CUSTOM_OBJECT_AVAILABLE_FOR_CUSTOMER_PORTAL
           );
           response.push({
             id: customObject.Id,
             name: customObject.DeveloperName,
             namespacePrefix: customObject.NamespacePrefix,
-            available: await page.$eval(
+            available: await classicPage.$eval(
               SELECTORS.CUSTOM_OBJECT_AVAILABLE_FOR_CUSTOMER_PORTAL,
               (el: HTMLInputElement) => el.checked
             )
@@ -135,9 +136,8 @@ export default class CustomerPortalAvailableCustomObjects extends BrowserforcePl
   }
 
   public async apply(plan) {
-    const page = this.browserforce.page;
     if (plan && plan.length) {
-      await page.goto(this.browserforce.getInstanceUrl(), {
+      const page = await this.browserforce.openPage('', {
         waitUntil: ['load', 'domcontentloaded', 'networkidle0']
       });
       // new URLs for LEX: https://help.salesforce.com/articleView?id=FAQ-for-the-New-URL-Format-for-Lightning-Experience-and-the-Salesforce-Mobile-App&type=1
@@ -149,17 +149,20 @@ export default class CustomerPortalAvailableCustomObjects extends BrowserforcePl
           customObject.available ? 1 : 0
         }&retURL=/${customObject.id}`;
         if (isLEX) {
-          const availableForCustomerPortalUrl = `${this.browserforce.getInstanceUrl()}/lightning/setup/ObjectManager/${
+          const availableForCustomerPortalPath = `lightning/setup/ObjectManager/${
             customObject.id
           }/edit?nodeId=ObjectManager&address=${encodeURIComponent(
             `/${classicUiPath}`
           )}`;
-          await page.goto(availableForCustomerPortalUrl, {
-            waitUntil: ['load', 'domcontentloaded', 'networkidle0']
-          });
+          const lexPage = await this.browserforce.openPage(
+            availableForCustomerPortalPath,
+            {
+              waitUntil: ['load', 'domcontentloaded', 'networkidle0']
+            }
+          );
           // maybe use waitForFrame https://github.com/GoogleChrome/puppeteer/issues/1361
-          await page.waitFor(SELECTORS.IFRAME);
-          const frame = await page
+          await lexPage.waitFor(SELECTORS.IFRAME);
+          const frame = await lexPage
             .frames()
             .find(f => f.name().startsWith('vfFrameId'));
           await frame.waitFor(SELECTORS.SAVE_BUTTON);
@@ -169,12 +172,11 @@ export default class CustomerPortalAvailableCustomObjects extends BrowserforcePl
             frame.click(SELECTORS.SAVE_BUTTON)
           ]);
         } else {
-          const availableForCustomerPortalUrl = `${this.browserforce.getInstanceUrl()}/${classicUiPath}`;
-          await page.goto(availableForCustomerPortalUrl);
-          await page.waitFor(SELECTORS.SAVE_BUTTON);
+          const classicPage = await this.browserforce.openPage(classicUiPath);
+          await classicPage.waitFor(SELECTORS.SAVE_BUTTON);
           await Promise.all([
-            page.waitForNavigation(),
-            page.click(SELECTORS.SAVE_BUTTON)
+            classicPage.waitForNavigation(),
+            classicPage.click(SELECTORS.SAVE_BUTTON)
           ]);
         }
       }

--- a/src/plugins/customer-portal/enabled/index.ts
+++ b/src/plugins/customer-portal/enabled/index.ts
@@ -5,19 +5,14 @@ const PATHS = {
 };
 const SELECTORS = {
   ENABLED: '#penabled',
-  ERROR_DIV: '#errorTitle',
   SAVE_BUTTON: 'input[name="save"]'
 };
 
 export default class CustomerPortalEnable extends BrowserforcePlugin {
   public async retrieve(definition?) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.EDIT_VIEW}`);
-    await page.waitFor(SELECTORS.ENABLED);
-    const customerPortalNotAvailable = await page.$(SELECTORS.ERROR_DIV);
-    if (customerPortalNotAvailable) {
-      throw new Error('Customer Portal is not available in this org');
-    }
+    const page = await this.browserforce.openPage(PATHS.EDIT_VIEW, {
+      waitUntil: ['load', 'domcontentloaded', 'networkidle0']
+    });
     await page.waitFor(SELECTORS.ENABLED);
     const response = await page.$eval(
       SELECTORS.ENABLED,
@@ -36,11 +31,9 @@ export default class CustomerPortalEnable extends BrowserforcePlugin {
     if (plan === false) {
       throw new Error('`enabled` cannot be disabled once enabled');
     }
-    const page = this.browserforce.page;
+
     if (plan) {
-      await page.goto(
-        `${this.browserforce.getInstanceUrl()}/${PATHS.EDIT_VIEW}`
-      );
+      const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
       await page.waitFor(SELECTORS.ENABLED);
       await page.$eval(
         SELECTORS.ENABLED,

--- a/src/plugins/customer-portal/index.e2e-spec.ts
+++ b/src/plugins/customer-portal/index.e2e-spec.ts
@@ -8,8 +8,8 @@ import CustomerPortalSetup from './portals';
 describe(CustomerPortalEnable.name, () => {
   const dir = path.resolve(path.join(__dirname, 'enabled'));
   it('should enable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -22,8 +22,8 @@ describe(CustomerPortalEnable.name, () => {
     );
   });
   it('should already be enabled', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -36,8 +36,8 @@ describe(CustomerPortalEnable.name, () => {
     );
   });
   it('should fail to disable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -59,8 +59,8 @@ describe(CustomerPortalSetup.name, () => {
   const dir = path.resolve(path.join(__dirname, 'portals'));
   describe('portals', () => {
     it('should fail to set portal admin user without permset', function() {
-      this.timeout(1000 * 60);
-      this.slow(1000 * 15);
+      this.timeout(1000 * 90);
+      this.slow(1000 * 30);
       const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
         'browserforce:apply',
         '-f',
@@ -85,8 +85,8 @@ describe(CustomerPortalSetup.name, () => {
       );
     });
     it('should setup user for portal', function() {
-      this.timeout(1000 * 120);
-      this.slow(1000 * 15);
+      this.timeout(1000 * 180);
+      this.slow(1000 * 30);
       const sourceDeployCmd = child.spawnSync('sfdx', [
         'force:source:deploy',
         '-p',
@@ -117,8 +117,8 @@ describe(CustomerPortalSetup.name, () => {
       );
     });
     it('should setup portal', function() {
-      this.timeout(1000 * 120);
-      this.slow(1000 * 15);
+      this.timeout(1000 * 180);
+      this.slow(1000 * 30);
       const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
         'browserforce:apply',
         '-f',
@@ -149,8 +149,8 @@ describe(CustomerPortalSetup.name, () => {
       );
     });
     it('should already be set up', function() {
-      this.timeout(1000 * 60);
-      this.slow(1000 * 15);
+      this.timeout(1000 * 90);
+      this.slow(1000 * 30);
       const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
         'browserforce:apply',
         '-f',
@@ -172,8 +172,8 @@ describe(CustomerPortalSetup.name, () => {
 describe(CustomerPortalAvailableCustomObjects.name, () => {
   const dir = path.resolve(path.join(__dirname, 'availableCustomObjects'));
   it('should fail to make non-existent custom objects available for customer portal', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -190,8 +190,8 @@ describe(CustomerPortalAvailableCustomObjects.name, () => {
     );
   });
   it('should deploy custom object', function() {
-    this.timeout(1000 * 120);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 180);
+    this.slow(1000 * 30);
     const sourceDeployCmd = child.spawnSync('sfdx', [
       'force:source:deploy',
       '-p',
@@ -208,8 +208,8 @@ describe(CustomerPortalAvailableCustomObjects.name, () => {
     );
   });
   it('should make custom objects available for customer portal', function() {
-    this.timeout(1000 * 120);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 180);
+    this.slow(1000 * 30);
     const setupCustomObjectsCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -228,8 +228,8 @@ describe(CustomerPortalAvailableCustomObjects.name, () => {
     );
   });
   it('should have applied checkbox available for customer portal', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const setupCustomObjectsCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -246,8 +246,8 @@ describe(CustomerPortalAvailableCustomObjects.name, () => {
     );
   });
   it('should make custom objects unavailable for customer portal', function() {
-    this.timeout(1000 * 120);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 180);
+    this.slow(1000 * 30);
     const setupCustomObjectsCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',

--- a/src/plugins/home-page-layouts/index.e2e-spec.ts
+++ b/src/plugins/home-page-layouts/index.e2e-spec.ts
@@ -5,8 +5,8 @@ import HomePageLayouts from '.';
 
 describe(HomePageLayouts.name, () => {
   it('should assign the home page default', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const assignHomePageDefaultCmd = child.spawnSync(
       path.resolve('bin', 'run'),
       [
@@ -28,8 +28,8 @@ describe(HomePageLayouts.name, () => {
     );
   });
   it('should assign the org default', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const assignOrgDefaultCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',

--- a/src/plugins/home-page-layouts/index.ts
+++ b/src/plugins/home-page-layouts/index.ts
@@ -22,8 +22,7 @@ interface HomePageLayoutRecord {
 
 export default class HomePageLayouts extends BrowserforcePlugin {
   public async retrieve(definition?) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.BASE);
     const profiles = await page.$$eval(
       'table.detailList tbody tr td label',
@@ -89,8 +88,8 @@ export default class HomePageLayouts extends BrowserforcePlugin {
       .tooling.query<HomePageLayoutRecord>(
         `SELECT Id, Name FROM HomePageLayout WHERE Name IN (${layoutsList})`
       );
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.BASE);
     for (const assignment of config.homePageLayoutAssignments) {
       const homePageLayoutName = assignment.layout;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -2,9 +2,4 @@ import * as customerPortal from './customer-portal';
 import * as homePageLayouts from './home-page-layouts';
 import * as salesforceToSalesforce from './salesforce-to-salesforce';
 import * as security from './security';
-export {
-  customerPortal,
-  homePageLayouts,
-  salesforceToSalesforce,
-  security
-};
+export { customerPortal, homePageLayouts, salesforceToSalesforce, security };

--- a/src/plugins/salesforce-to-salesforce/index.e2e-spec.ts
+++ b/src/plugins/salesforce-to-salesforce/index.e2e-spec.ts
@@ -5,8 +5,8 @@ import SalesforceToSalesforce from '.';
 
 describe(SalesforceToSalesforce.name, () => {
   it('should enable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -19,8 +19,8 @@ describe(SalesforceToSalesforce.name, () => {
     );
   });
   it('should fail to disable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',

--- a/src/plugins/salesforce-to-salesforce/index.ts
+++ b/src/plugins/salesforce-to-salesforce/index.ts
@@ -11,8 +11,7 @@ const SELECTORS = {
 
 export default class SalesforceToSalesforce extends BrowserforcePlugin {
   public async retrieve() {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.BASE);
     const response = {};
     const inputEnable = await page.$(SELECTORS.ENABLED);
@@ -30,12 +29,10 @@ export default class SalesforceToSalesforce extends BrowserforcePlugin {
 
   public async apply(config) {
     if (config.enabled === false) {
-      throw new Error(
-        '`enabled` cannot be disabled once enabled'
-      );
+      throw new Error('`enabled` cannot be disabled once enabled');
     }
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.ENABLED);
     await page.$eval(
       SELECTORS.ENABLED,

--- a/src/plugins/security/certificate-and-key-management/index.ts
+++ b/src/plugins/security/certificate-and-key-management/index.ts
@@ -83,7 +83,6 @@ export default class CertificateAndKeyManagement extends BrowserforcePlugin {
   }
 
   public async apply(plan) {
-    const page = this.browserforce.page;
     if (plan.certificates) {
       for (const certificate of plan.certificates) {
         if (certificate.id) {
@@ -100,10 +99,8 @@ export default class CertificateAndKeyManagement extends BrowserforcePlugin {
           if (certificate.exportable !== undefined) {
             urlAttributes['exp'] = certificate.exportable ? 1 : 0;
           }
-          await page.goto(
-            `${this.browserforce.getInstanceUrl()}/${
-              PATHS.CERT_PREFIX
-            }/e?${queryString.stringify(urlAttributes)}`
+          const page = await this.browserforce.openPage(
+            `${PATHS.CERT_PREFIX}/e?${queryString.stringify(urlAttributes)}`
           );
           await page.waitFor(SELECTORS.SAVE_BUTTON);
           await Promise.all([
@@ -115,8 +112,8 @@ export default class CertificateAndKeyManagement extends BrowserforcePlugin {
     }
     if (plan.importFromKeystore) {
       for (const certificate of plan.importFromKeystore) {
-        await page.goto(
-          `${this.browserforce.getInstanceUrl()}/${PATHS.KEYSTORE_IMPORT}`
+        const page = await this.browserforce.openPage(
+          `${PATHS.KEYSTORE_IMPORT}`
         );
         await page.waitFor(SELECTORS.FILE_UPLOAD);
         const elementHandle = await page.$(SELECTORS.FILE_UPLOAD);
@@ -140,17 +137,15 @@ export default class CertificateAndKeyManagement extends BrowserforcePlugin {
               `SELECT Id FROM Certificate WHERE DeveloperName = '${certificate.name.toLowerCase()}'`
             );
           const importedCert = certsResponse.records[0];
-          await page.goto(
-            `${this.browserforce.getInstanceUrl()}/${
-              importedCert.Id
-            }/e?MasterLabel=${certificate.name}&DeveloperName=${
+          const certPage = await this.browserforce.openPage(
+            `${importedCert.Id}/e?MasterLabel=${
               certificate.name
-            }`
+            }&DeveloperName=${certificate.name}`
           );
-          await page.waitFor(SELECTORS.SAVE_BUTTON);
+          await certPage.waitFor(SELECTORS.SAVE_BUTTON);
           await Promise.all([
-            page.waitForNavigation(),
-            page.click(SELECTORS.SAVE_BUTTON)
+            certPage.waitForNavigation(),
+            certPage.click(SELECTORS.SAVE_BUTTON)
           ]);
         }
       }

--- a/src/plugins/security/identity-provider/index.ts
+++ b/src/plugins/security/identity-provider/index.ts
@@ -22,8 +22,7 @@ interface CertificateRecord {
 
 export default class IdentityProvider extends BrowserforcePlugin {
   public async retrieve(definition?) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.EDIT_VIEW}`);
+    const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
     await page.waitFor(SELECTORS.EDIT_BUTTON);
     const disableButton = await page.$(SELECTORS.DISABLE_BUTTON);
     const certNameHandle = await page.$(SELECTORS.CERT_NAME_SPAN);
@@ -44,7 +43,6 @@ export default class IdentityProvider extends BrowserforcePlugin {
   }
 
   public async apply(plan) {
-    const page = this.browserforce.page;
     if (plan.enabled && plan.certificate && plan.certificate !== '') {
       // wait for cert to become available in Identity Provider UI
       await retry(
@@ -59,9 +57,7 @@ export default class IdentityProvider extends BrowserforcePlugin {
           if (!certsResponse.records.length) {
             throw new Error(`Could not find Certificate '${plan.certificate}'`);
           }
-          await page.goto(
-            `${this.browserforce.getInstanceUrl()}/${PATHS.EDIT_VIEW}`
-          );
+          const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
           await page.waitFor(SELECTORS.EDIT_BUTTON);
           await Promise.all([
             page.waitForNavigation(),
@@ -103,9 +99,7 @@ export default class IdentityProvider extends BrowserforcePlugin {
         2000
       );
     } else {
-      await page.goto(
-        `${this.browserforce.getInstanceUrl()}/${PATHS.EDIT_VIEW}`
-      );
+      const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
       await page.waitFor(SELECTORS.EDIT_BUTTON);
       await page.$(SELECTORS.DISABLE_BUTTON);
       page.on('dialog', async dialog => {

--- a/src/plugins/security/index.e2e-spec.ts
+++ b/src/plugins/security/index.e2e-spec.ts
@@ -8,8 +8,8 @@ describe(`${CertificateAndKeyManagement.name} and ${
   IdentityProvider.name
 }`, () => {
   it('should fail to enable identity provider with non-existing Certificate', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const cmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -30,8 +30,8 @@ describe(`${CertificateAndKeyManagement.name} and ${
     );
   });
   it('should create a self-signed certificate and enable Identity Provider', function() {
-    this.timeout(1000 * 120);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 180);
+    this.slow(1000 * 30);
     const cmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -54,8 +54,8 @@ describe(`${CertificateAndKeyManagement.name} and ${
     );
   });
   it('should disable Identity Provider', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const cmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -70,8 +70,8 @@ describe(`${CertificateAndKeyManagement.name} and ${
     );
   });
   it.skip('should not do anything if self-signed certificate is already available', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const cmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -90,8 +90,8 @@ describe(`${CertificateAndKeyManagement.name} and ${
     );
   });
   it('should import a cert from a keystore', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const cmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',

--- a/src/plugins/security/login-access-policies/index.e2e-spec.ts
+++ b/src/plugins/security/login-access-policies/index.e2e-spec.ts
@@ -5,8 +5,8 @@ import LoginAccessPolicies from '.';
 
 describe(LoginAccessPolicies.name, () => {
   it('should enable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -21,8 +21,8 @@ describe(LoginAccessPolicies.name, () => {
     );
   });
   it('should disable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',

--- a/src/plugins/security/login-access-policies/index.ts
+++ b/src/plugins/security/login-access-policies/index.ts
@@ -11,8 +11,7 @@ const SELECTORS = {
 
 export default class LoginAccessPolicies extends BrowserforcePlugin {
   public async retrieve(definition?) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.ENABLED);
     const response = {
       administratorsCanLogInAsAnyUser: await page.$eval(
@@ -24,8 +23,7 @@ export default class LoginAccessPolicies extends BrowserforcePlugin {
   }
 
   public async apply(config) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.ENABLED);
     await page.$eval(
       SELECTORS.ENABLED,

--- a/src/plugins/security/sharing/index.e2e-spec.ts
+++ b/src/plugins/security/sharing/index.e2e-spec.ts
@@ -5,8 +5,8 @@ import Sharing from '.';
 
 describe(Sharing.name, () => {
   it('should enable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',
@@ -21,8 +21,8 @@ describe(Sharing.name, () => {
     );
   });
   it('should disable', function() {
-    this.timeout(1000 * 60);
-    this.slow(1000 * 15);
+    this.timeout(1000 * 90);
+    this.slow(1000 * 30);
     const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
       'browserforce:apply',
       '-f',

--- a/src/plugins/security/sharing/index.ts
+++ b/src/plugins/security/sharing/index.ts
@@ -13,8 +13,7 @@ const SELECTORS = {
 
 export default class Sharing extends BrowserforcePlugin {
   public async retrieve(definition?) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.EXTERNAL_SHARING_MODEL_BUTTON);
     const buttonOnclick = await page.$eval(
       SELECTORS.EXTERNAL_SHARING_MODEL_BUTTON,
@@ -27,8 +26,7 @@ export default class Sharing extends BrowserforcePlugin {
   }
 
   public async apply(config) {
-    const page = this.browserforce.page;
-    await page.goto(`${this.browserforce.getInstanceUrl()}/${PATHS.BASE}`);
+    const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitFor(SELECTORS.EXTERNAL_SHARING_MODEL_BUTTON);
     page.on('dialog', async dialog => {
       await dialog.accept();

--- a/src/plugins/utils.ts
+++ b/src/plugins/utils.ts
@@ -3,20 +3,29 @@ export async function retry(
   fn,
   retriesLeft = 5,
   interval = 1000,
-  exponential = false
+  exponential = false,
+  errorPrototype = Error.prototype,
+  logger?
 ) {
   try {
     const val = await fn();
     return val;
   } catch (error) {
-    if (retriesLeft) {
+    if (errorPrototype.isPrototypeOf(error) && retriesLeft) {
+      if (logger) {
+        logger.warn(
+          `retrying ${retriesLeft} more time(s) because of "${error}"`
+        );
+      }
       // tslint:disable-next-line no-string-based-set-timeout
       await new Promise(r => setTimeout(r, interval));
       return retry(
         fn,
         retriesLeft - 1,
         exponential ? interval * 2 : interval,
-        exponential
+        exponential,
+        errorPrototype,
+        logger
       );
     } else throw error;
   }

--- a/test/browserforce.e2e-spec.ts
+++ b/test/browserforce.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { core } from '@salesforce/command';
+import { core, UX } from '@salesforce/command';
 import * as assert from 'assert';
 import Browserforce from '../src/browserforce';
 
@@ -8,7 +8,8 @@ describe('Browser', () => {
       this.timeout(1000 * 180);
       this.slow(1000 * 30);
       const defaultScratchOrg = await core.Org.create({});
-      const bf = new Browserforce(defaultScratchOrg);
+      const ux = await UX.create();
+      const bf = new Browserforce(defaultScratchOrg, ux.cli);
       await bf.login();
       await bf.logout();
       assert(true);
@@ -22,7 +23,7 @@ describe('Browser', () => {
       const bf = new Browserforce(fakeOrg);
       await assert.rejects(async () => {
         await bf.login();
-      }, /login failed \[302\]/);
+      }, /login failed/);
       bf.logout();
     });
   });

--- a/test/browserforce.e2e-spec.ts
+++ b/test/browserforce.e2e-spec.ts
@@ -5,8 +5,8 @@ import Browserforce from '../src/browserforce';
 describe('Browser', () => {
   describe('login()', () => {
     it('should successfully login with valid credentials', async function() {
-      this.timeout(1000 * 60);
-      this.slow(1000 * 10);
+      this.timeout(1000 * 180);
+      this.slow(1000 * 30);
       const defaultScratchOrg = await core.Org.create({});
       const bf = new Browserforce(defaultScratchOrg);
       await bf.login();
@@ -15,8 +15,8 @@ describe('Browser', () => {
     });
 
     it('should fail login with invalid credentials', async function() {
-      this.timeout(1000 * 60);
-      this.slow(1000 * 10);
+      this.timeout(1000 * 180);
+      this.slow(1000 * 30);
       const fakeOrg = await core.Org.create({});
       fakeOrg.getConnection().accessToken = 'invalid';
       const bf = new Browserforce(fakeOrg);


### PR DESCRIPTION
Logging in using frontdoor sometimes stops at URLs like `https://test.salesforce.com/?ec=302&startURL=` indicating the login failed.
However the login was successful.
Opening another page with the instance URL in the same browser seems to
do the trick.

Encapsulate retry logic in browserforce.openPage

- resolve IP addresses of classic and LEX domains
- check response for errors

This should resolve many errors like

> ERROR running BrowserforceApply:
> waiting for selector "#penabled" failed: timeout 30000ms exceeded

and

> ERROR running BrowserforceApply:
> login failed [302]: {"instanceUrl": "https://velocity-speed-2098-dev-ed.cs50.my.salesforce.com/, "url": "https://test.salesforce.com"}"