### PR TITLE
fix: throw page error on 500 if there is one

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "name": "Attach to Remote",
             "address": "127.0.0.1",
             "port": 9229,
-            "localRoot": "${workspaceFolder}"
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "${workspaceFolder}"
         },
         {
             "name": "Unit Tests",

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Here is a full blown example showing most of the supported settings in action:
 
 - `BROWSER_DEBUG` run in non-headless mode (default: `false`)
 - `BROWSERFORCE_NAVIGATION_TIMEOUT_MS`: adjustable for slow internet connections (default: `90000`)
+- `BROWSERFORCE_RETRY_MAX_RETRIES`: number of retries on failures opening a page (default: `4`)
+- `BROWSERFORCE_RETRY_TIMEOUT_MS`: initial time between retries in exponential mode (default: `4000`)
 
 # Contributing
 

--- a/src/browserforce.ts
+++ b/src/browserforce.ts
@@ -95,6 +95,7 @@ export default class Browserforce {
         const response = await page.goto(url, options);
         if (response) {
           if (!response.ok()) {
+            await this.throwPageErrors(page);
             throw new Error(`${response.status()}: ${response.statusText()}`);
           }
           if (response.url().indexOf('/?ec=302') > 0) {
@@ -136,7 +137,6 @@ export default class Browserforce {
             }
           }
         }
-        // await this.throwPageErrors(page);
         return page;
       },
       {

--- a/src/browserforce.ts
+++ b/src/browserforce.ts
@@ -147,8 +147,12 @@ export default class Browserforce {
             );
           }
         },
-        retries: 4,
-        minTimeout: 4 * 1000
+        retries: process.env.BROWSERFORCE_RETRY_MAX_RETRIES
+          ? parseInt(process.env.BROWSERFORCE_RETRY_MAX_RETRIES, 10)
+          : 4,
+        minTimeout: process.env.BROWSERFORCE_RETRY_TIMEOUT_MS
+          ? parseInt(process.env.BROWSERFORCE_RETRY_TIMEOUT_MS, 10)
+          : 4000
       }
     );
     return result;

--- a/test/browserforce.e2e-spec.ts
+++ b/test/browserforce.e2e-spec.ts
@@ -67,4 +67,34 @@ describe('Browser', () => {
       await bf.logout();
     });
   });
+  describe('throwPageErrors()', () => {
+    it('should throw the page error on internal errors', async function() {
+      this.timeout(1000 * 300);
+      this.slow(1000 * 30);
+      const defaultScratchOrg = await core.Org.create({});
+      const ux = await UX.create();
+      const bf = new Browserforce(defaultScratchOrg, ux.cli);
+      await bf.login();
+      process.env.BROWSERFORCE_RETRY_TIMEOUT_MS = '0';
+      await assert.rejects(async () => {
+        await bf.openPage(
+          '_ui/common/config/field/StandardFieldAttributes/d?type=Account&id=INVALID_Name'
+        );
+      }, /Insufficient Privileges/);
+      delete process.env.BROWSERFORCE_RETRY_TIMEOUT_MS;
+      await bf.logout();
+    });
+    it('should not throw any error opening a page', async function() {
+      this.timeout(1000 * 300);
+      this.slow(1000 * 30);
+      const defaultScratchOrg = await core.Org.create({});
+      const ux = await UX.create();
+      const bf = new Browserforce(defaultScratchOrg, ux.cli);
+      await bf.login();
+      await bf.openPage(
+        '_ui/common/config/field/StandardFieldAttributes/d?type=Account&id=Name'
+      );
+      await bf.logout();
+    });
+  });
 });


### PR DESCRIPTION
This should reveal errors like

> An error has occurred in the following section: [Exception, DomainNotPropagated_desc].
> Salesforce.com has been notified of this error.