### PR TITLE
test: temporarily disable tests for Sharing

### DIFF
--- a/src/plugins/security/sharing/index.e2e-spec.ts
+++ b/src/plugins/security/sharing/index.e2e-spec.ts
@@ -3,7 +3,7 @@ import * as child from 'child_process';
 import * as path from 'path';
 import Sharing from '.';
 
-describe(Sharing.name, () => {
+describe.skip(Sharing.name, () => {
   it('should enable', function() {
     this.timeout(1000 * 90);
     this.slow(1000 * 30);


### PR DESCRIPTION
Scratch orgs with the Winter 20 release
have different Organization-Wide Defaults (internal/external) set on
Users and Individuals, making it impossible to simply deactivate
External Sharing after activating it.