### PR TITLE
fix: prevent ERR_TOO_MANY_REDIRECTS

### DIFF
--- a/src/browserforce.ts
+++ b/src/browserforce.ts
@@ -201,7 +201,8 @@ export default class Browserforce {
   }
 
   public getInstanceUrl() {
-    return this.org.getConnection().instanceUrl;
+    // sometimes the instanceUrl includes a trailing slash
+    return this.org.getConnection().instanceUrl?.replace(/\/$/, '');
   }
 
   public getLightningUrl() {


### PR DESCRIPTION
Sometimes the instanceUrl contains a trailing slash.
When building a URL for opening in the browser,
this can lead to two consecutive slashes.
This removes trailing slashes to prevent this.