### PR TITLE
feat: (de)activate picklist values

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Here is a full blown example showing most of the supported settings in action:
           "value": "CD",
           "newValue": "Media",
           "absent": true
+        },
+        {
+          "metadataType": "CustomField",
+          "metadataFullName": "Vehicle__c.Features__c",
+          "value": "CD",
+          "newValue": "AC",
+          "active": false
         }
       ]
     },

--- a/src/plugins/picklists/activate.json
+++ b/src/plugins/picklists/activate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "picklists": {
+      "picklistValues": [
+        {
+          "metadataType": "CustomField",
+          "metadataFullName": "Vehicle__c.Features__c",
+          "value": "AC",
+          "active": true
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/picklists/deactivate.json
+++ b/src/plugins/picklists/deactivate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "picklists": {
+      "picklistValues": [
+        {
+          "metadataType": "CustomField",
+          "metadataFullName": "Vehicle__c.Features__c",
+          "value": "AC",
+          "active": false
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/picklists/index.e2e-spec.ts
+++ b/src/plugins/picklists/index.e2e-spec.ts
@@ -55,4 +55,40 @@ describe(Picklists.name, function() {
       replaceCmd.output.toString()
     );
   });
+  it('should deactivate picklist value', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'deactivate.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'picklistValues' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should activate picklist value', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'activate.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'picklistValues' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should not do anything when the picklist values do not exist', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'activate.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /no action necessary/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
 });

--- a/src/plugins/picklists/index.ts
+++ b/src/plugins/picklists/index.ts
@@ -49,7 +49,12 @@ export default class Picklists extends BrowserforcePlugin {
       );
       const page = await this.browserforce.openPage(picklistUrl);
       const picklistPage = new PicklistPage(page);
-      if (action.absent) {
+      if (action.active !== undefined) {
+        await picklistPage.clickActivateDeactivateActionForValue(
+          action.value,
+          action.active
+        );
+      } else if (action.absent) {
         const replacePage = await picklistPage.clickDeleteActionForValue(
           action.value
         );
@@ -104,10 +109,16 @@ function isActionRequired(action, values) {
   const valueGiven = action.value !== undefined && action.value !== null;
   const newValueGiven =
     action.newValue !== undefined && action.newValue !== null;
-  if (valueGiven && !values.includes(action.value)) {
-    return false;
+  if (valueGiven) {
+    const match = values.find(x => x.value === action.value);
+    if (!match) {
+      return false;
+    }
+    if (action.active !== undefined && action.active === match.active) {
+      return false;
+    }
   }
-  if (newValueGiven && !values.includes(action.newValue)) {
+  if (newValueGiven && !values.find(x => x.value === action.newValue)) {
     return false;
   }
   return true;

--- a/src/plugins/picklists/schema.json
+++ b/src/plugins/picklists/schema.json
@@ -37,6 +37,10 @@
           "type": "boolean",
           "description": "replace all blank values (mutually exclusive to replacing an old value)"
         },
+        "active": {
+          "type": "boolean",
+          "description": "ensure the picklist value is active/inactive"
+        },
         "absent": {
           "type": "boolean",
           "description": "ensure the picklist value is absent/deleted"


### PR DESCRIPTION
Example config for deactivating a picklist value:

```json
{
  "$schema": "https://raw.githubusercontent.com/amtrack/sfdx-browserforce-plugin/master/src/plugins/schema.json",
  "settings": {
    "picklists": {
      "picklistValues": [
        {
          "metadataType": "CustomField",
          "metadataFullName": "Vehicle__c.Features__c",
          "value": "AC",
          "active": false
        }
      ]
    }
  }
}
```