### PR TITLE
feat: allow managing field dependencies (on installed CustomFields) 

### DIFF
--- a/src/plugins/picklists/field-dependencies/change.json
+++ b/src/plugins/picklists/field-dependencies/change.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schema.json",
+  "settings": {
+    "picklists": {
+      "fieldDependencies": [
+        {
+          "object": "Vehicle__c",
+          "dependentField": "Gears__c",
+          "controllingField": "Features__c"
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/picklists/field-dependencies/index.ts
+++ b/src/plugins/picklists/field-dependencies/index.ts
@@ -1,0 +1,71 @@
+import { BrowserforcePlugin } from '../../../plugin';
+import { FieldDependencyPage, NewFieldDependencyPage } from './pages';
+
+export default class FieldDependencies extends BrowserforcePlugin {
+  public async retrieve(definition?) {
+    const conn = this.org.getConnection();
+    const dependentFieldNames = definition.map(
+      f => `${f.object}.${f.dependentField}`
+    );
+    const result = await conn.metadata.read('CustomField', dependentFieldNames);
+    const metadata = Array.isArray(result) ? result : [result];
+    const state = definition.map(f => {
+      const fieldState = { ...f };
+      const field = metadata.find(
+        m => m.fullName === `${f.object}.${f.dependentField}`
+      );
+      fieldState.controllingField = field?.['valueSet']?.controllingField;
+      return fieldState;
+    });
+    return state;
+  }
+
+  public async apply(plan) {
+    const conn = this.org.getConnection();
+    const listMetadataResult = await conn.metadata.list([
+      {
+        type: 'CustomObject'
+      },
+      { type: 'CustomField' }
+    ]);
+    const fileProperties = Array.isArray(listMetadataResult)
+      ? listMetadataResult
+      : [listMetadataResult];
+    for (const dep of plan) {
+      const customObject = fileProperties.find(
+        x => x.type === 'CustomObject' && x.fullName === dep.object
+      );
+      const dependentField = fileProperties.find(
+        x =>
+          x.type === 'CustomField' &&
+          x.fullName === `${dep.object}.${dep.dependentField}`
+      );
+      // always try deleting an existing dependency first
+      const fieldDependenciesPage = new FieldDependencyPage(
+        await this.browserforce.openPage(
+          FieldDependencyPage.getUrl(customObject.id)
+        )
+      );
+      await fieldDependenciesPage.clickDeleteDependencyActionForField(
+        dependentField.id
+      );
+      if (dep.controllingField) {
+        const controllingField = fileProperties.find(
+          x =>
+            x.type === 'CustomField' &&
+            x.fullName === `${dep.object}.${dep.controllingField}`
+        );
+        const newFieldDependencyPage = new NewFieldDependencyPage(
+          await this.browserforce.openPage(
+            NewFieldDependencyPage.getUrl(
+              customObject.id,
+              dependentField.id,
+              controllingField.id
+            )
+          )
+        );
+        await newFieldDependencyPage.save();
+      }
+    }
+  }
+}

--- a/src/plugins/picklists/field-dependencies/pages.ts
+++ b/src/plugins/picklists/field-dependencies/pages.ts
@@ -1,0 +1,86 @@
+import { throwPageErrors } from '../../../browserforce';
+
+export class FieldDependencyPage {
+  private page;
+
+  constructor(page) {
+    this.page = page;
+  }
+
+  public static getUrl(customObjectId: string): string {
+    return `setup/ui/dependencyList.jsp?tableEnumOrId=${customObjectId.substring(
+      0,
+      15
+    )}&setupid=CustomObjects`;
+  }
+
+  public async clickDeleteDependencyActionForField(
+    customFieldId: string
+  ): Promise<any> {
+    // wait for "new" button in field dependencies releated list header
+    await this.page.waitForSelector(
+      'div.listRelatedObject div.pbHeader input[name="new"]'
+    );
+    const xpath = `//a[contains(@href, "/p/dependency/NewDependencyUI/e") and contains(@href, "delID=${customFieldId.substring(
+      0,
+      15
+    )}")]`;
+    const actionLinkHandles = await this.page.$x(xpath);
+    if (actionLinkHandles.length) {
+      this.page.on('dialog', async dialog => {
+        await dialog.accept();
+      });
+      await Promise.all([
+        this.page.waitForNavigation(),
+        actionLinkHandles[0].click()
+      ]);
+      await throwPageErrors(this.page);
+    }
+    return this.page;
+  }
+}
+
+export class NewFieldDependencyPage {
+  protected page;
+  protected saveButton = 'input[name="save"]';
+
+  constructor(page) {
+    this.page = page;
+  }
+
+  public static getUrl(
+    customObjectId: string,
+    dependentFieldId: string,
+    controllingFieldId: string
+  ): string {
+    return `p/dependency/NewDependencyUI/e?tableEnumOrId=${customObjectId.substring(
+      0,
+      15
+    )}&setupid=CustomObjects&controller=${controllingFieldId.substring(
+      0,
+      15
+    )}&dependent=${dependentFieldId.substring(
+      0,
+      15
+    )}&retURL=/${customObjectId.substring(0, 15)}`;
+  }
+
+  async save() {
+    await this.page.waitForSelector(this.saveButton);
+    await Promise.all([
+      this.page.waitForNavigation(),
+      this.page.click(this.saveButton)
+    ]);
+    await throwPageErrors(this.page);
+    // second step in wizard
+    this.page.on('dialog', async dialog => {
+      await dialog.accept();
+    });
+    await this.page.waitForSelector(this.saveButton);
+    await Promise.all([
+      this.page.waitForNavigation(),
+      this.page.click(this.saveButton)
+    ]);
+    await throwPageErrors(this.page);
+  }
+}

--- a/src/plugins/picklists/field-dependencies/schema.json
+++ b/src/plugins/picklists/field-dependencies/schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/picklists/controlling-field/schema.json",
+  "title": "Field Dependencies",
+  "description": "Manage (create/modify/delete) Field Dependencies on CustomFields.\nIf a Field Dependency already exists for the dependent field, it will be deleted.",
+  "type": "array",
+  "items": { "$ref": "#/definitions/fieldDependency" },
+  "default": [],
+  "definitions": {
+    "fieldDependency": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "title": "the API name of the CustomObject",
+          "examples": ["Account", "Vehicle__c", "ACME__Vehicle__c"],
+          "type": "string"
+        },
+        "dependentField": {
+          "title": "the API name of the CustomField that has its values filtered",
+          "type": "string",
+          "examples": ["Gears__c", "ACME__Gears__c"]
+        },
+        "controllingField": {
+          "title": "the API name of the CustomField that drives filtering",
+          "description": "If this value is null or not set, the Field Dependency will be deleted.",
+          "type": ["string", "null"],
+          "examples": ["Transmission__c", "ACME__Transmission__c", null]
+        }
+      }
+    }
+  }
+}

--- a/src/plugins/picklists/field-dependencies/set.json
+++ b/src/plugins/picklists/field-dependencies/set.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schema.json",
+  "settings": {
+    "picklists": {
+      "fieldDependencies": [
+        {
+          "object": "Vehicle__c",
+          "dependentField": "Gears__c",
+          "controllingField": "Transmission__c"
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/picklists/field-dependencies/unset.json
+++ b/src/plugins/picklists/field-dependencies/unset.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../schema.json",
+  "settings": {
+    "picklists": {
+      "fieldDependencies": [
+        {
+          "object": "Vehicle__c",
+          "dependentField": "Gears__c",
+          "controllingField": null
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/picklists/index.e2e-spec.ts
+++ b/src/plugins/picklists/index.e2e-spec.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as child from 'child_process';
 import * as path from 'path';
 import Picklists from '.';
+import FieldDependencies from './field-dependencies';
 
 describe(Picklists.name, function() {
   this.slow('30s');
@@ -101,6 +102,83 @@ describe(Picklists.name, function() {
     assert(
       /changing 'picklistValues' to.*/.test(replaceCmd.output.toString()),
       replaceCmd.output.toString()
+    );
+  });
+});
+
+describe(FieldDependencies.name, function() {
+  this.slow('30s');
+  this.timeout('10m');
+  it('should not do anything when the dependency is already set', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'field-dependencies', 'set.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /no action necessary/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should unset a field dependency', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'field-dependencies', 'unset.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should not do anything when the dependency is already unset', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'field-dependencies', 'unset.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /no action necessary/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should set a field dependency', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'field-dependencies', 'set.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should change a field dependency', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'field-dependencies', 'change.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
+    );
+  });
+  it('should change back a field dependency', () => {
+    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'field-dependencies', 'set.json'))
+    ]);
+    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
+    assert(
+      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
+      cmd.output.toString()
     );
   });
 });

--- a/src/plugins/picklists/index.ts
+++ b/src/plugins/picklists/index.ts
@@ -1,100 +1,126 @@
 import { FileProperties } from 'jsforce';
 import { ensureArray } from '../../jsforce-utils';
 import { BrowserforcePlugin } from '../../plugin';
+import { removeEmptyValues } from '../utils';
+import FieldDependencies from './field-dependencies';
 import { PicklistPage } from './pages';
 import { determineStandardValueSetEditUrl } from './standard-value-set';
 
 export default class Picklists extends BrowserforcePlugin {
   public async retrieve(definition?) {
     const conn = this.org.getConnection();
-    const result = { picklistValues: [] };
-    const fileProperties = await listMetadata(
-      conn,
-      definition.picklistValues.map(x => x.metadataType)
-    );
-    for (const action of definition.picklistValues) {
-      // check if given picklist values exist
-      const picklistUrl = getPicklistUrl(
-        action.metadataType,
-        action.metadataFullName,
-        fileProperties
+    const result = { picklistValues: [], fieldDependencies: [] };
+    if (definition.picklistValues) {
+      const fileProperties = await listMetadata(
+        conn,
+        definition.picklistValues.map(x => x.metadataType)
       );
-      const page = await this.browserforce.openPage(picklistUrl);
-      const picklistPage = new PicklistPage(page);
-      const values = await picklistPage.getPicklistValues();
-      const state = { ...action };
-      const valueMatch =
-        action.value !== undefined
-          ? values.find(x => x.value === action.value)
-          : undefined;
-      const newValueMatch =
-        action.newValue !== undefined
-          ? values.find(x => x.value === action.newValue)
-          : undefined;
-      state.absent = !valueMatch;
-      state.active = valueMatch?.active;
-      state.newValueExists = Boolean(newValueMatch) || action.newValue === null;
-      result.picklistValues.push(state);
+      for (const action of definition.picklistValues) {
+        // check if given picklist values exist
+        const picklistUrl = getPicklistUrl(
+          action.metadataType,
+          action.metadataFullName,
+          fileProperties
+        );
+        const page = await this.browserforce.openPage(picklistUrl);
+        const picklistPage = new PicklistPage(page);
+        const values = await picklistPage.getPicklistValues();
+        const state = { ...action };
+        const valueMatch =
+          action.value !== undefined
+            ? values.find(x => x.value === action.value)
+            : undefined;
+        const newValueMatch =
+          action.newValue !== undefined
+            ? values.find(x => x.value === action.newValue)
+            : undefined;
+        state.absent = !valueMatch;
+        state.active = valueMatch?.active;
+        state.newValueExists =
+          Boolean(newValueMatch) || action.newValue === null;
+        result.picklistValues.push(state);
+      }
+    }
+    if (definition.fieldDependencies) {
+      result.fieldDependencies = await new FieldDependencies(
+        this.browserforce,
+        this.org
+      ).retrieve(definition.fieldDependencies);
     }
     return result;
   }
 
   public diff(state, definition) {
-    const actions = definition.picklistValues.filter((target, i) => {
-      const source = state.picklistValues[i];
-      if (target.absent) {
-        return target.absent !== source.absent;
-      }
-      if (target.active !== undefined) {
-        return target.active !== source.active;
-      }
-      // replacing a picklist value is not idempotent
-      if (
-        source.newValueExists &&
-        (target.value !== undefined || target.replaceAllBlankValues)
-      ) {
-        return true;
-      }
-      return false;
-    });
-    if (actions.length) {
-      return { picklistValues: actions };
+    const changes = {};
+    if (definition.picklistValues) {
+      changes['picklistValues'] = definition.picklistValues.filter(
+        (target, i) => {
+          const source = state.picklistValues[i];
+          if (target.absent) {
+            return target.absent !== source.absent;
+          }
+          if (target.active !== undefined) {
+            return target.active !== source.active;
+          }
+          // replacing a picklist value is not idempotent
+          if (
+            source.newValueExists &&
+            (target.value !== undefined || target.replaceAllBlankValues)
+          ) {
+            return true;
+          }
+          return false;
+        }
+      );
     }
-    return undefined;
+    if (definition.fieldDependencies) {
+      changes['fieldDependencies'] = new FieldDependencies(
+        this.browserforce,
+        this.org
+      ).diff(state.fieldDependencies, definition.fieldDependencies);
+    }
+    return removeEmptyValues(changes);
   }
 
   public async apply(config) {
     const conn = this.org.getConnection();
-    const fileProperties = await listMetadata(
-      conn,
-      config.picklistValues.map(x => x.metadataType)
-    );
-    for (const action of config.picklistValues) {
-      const picklistUrl = getPicklistUrl(
-        action.metadataType,
-        action.metadataFullName,
-        fileProperties
+    if (config.picklistValues) {
+      const fileProperties = await listMetadata(
+        conn,
+        config.picklistValues.map(x => x.metadataType)
       );
-      const page = await this.browserforce.openPage(picklistUrl);
-      const picklistPage = new PicklistPage(page);
-      if (action.active !== undefined) {
-        await picklistPage.clickActivateDeactivateActionForValue(
-          action.value,
-          action.active
+      for (const action of config.picklistValues) {
+        const picklistUrl = getPicklistUrl(
+          action.metadataType,
+          action.metadataFullName,
+          fileProperties
         );
-      } else if (action.absent) {
-        const replacePage = await picklistPage.clickDeleteActionForValue(
-          action.value
-        );
-        await replacePage.replaceAndDelete(action.newValue);
-      } else {
-        const replacePage = await picklistPage.clickReplaceActionButton();
-        await replacePage.replace(
-          action.value,
-          action.newValue,
-          action.replaceAllBlankValues
-        );
+        const page = await this.browserforce.openPage(picklistUrl);
+        const picklistPage = new PicklistPage(page);
+        if (action.active !== undefined) {
+          await picklistPage.clickActivateDeactivateActionForValue(
+            action.value,
+            action.active
+          );
+        } else if (action.absent) {
+          const replacePage = await picklistPage.clickDeleteActionForValue(
+            action.value
+          );
+          await replacePage.replaceAndDelete(action.newValue);
+        } else {
+          const replacePage = await picklistPage.clickReplaceActionButton();
+          await replacePage.replace(
+            action.value,
+            action.newValue,
+            action.replaceAllBlankValues
+          );
+        }
       }
+    }
+    if (config.fieldDependencies) {
+      await new FieldDependencies(this.browserforce, this.org).apply(
+        config.fieldDependencies
+      );
     }
   }
 }

--- a/src/plugins/picklists/schema.json
+++ b/src/plugins/picklists/schema.json
@@ -10,6 +10,9 @@
       "type": "array",
       "items": { "$ref": "#/definitions/action" },
       "default": []
+    },
+    "fieldDependencies": {
+      "$ref": "./field-dependencies/schema.json"
     }
   },
   "definitions": {


### PR DESCRIPTION
Manage (create/modify/delete) Field Dependencies on CustomFields.
If a Field Dependency already exists for the dependent field,
it will be deleted.

In general the Metadata and Tooling API can be used for this.
However these APIs throw the following error when trying to change
field dependencies for **installed** CustomFields:

> Cannot modify managed object: entity=CustomFieldDefinition,
component=00NXXXXXXXXXXXX, field=PicklistControllerEnumOrId,
state=installed, newValue='00NYYYYYYYYYYYY', oldValue='null'

**Examples**

Make sure the given field dependency exists:

```json
{
  "$schema": "https://raw.githubusercontent.com/amtrack/sfdx-browserforce-plugin/master/src/plugins/schema.json",
  "settings": {
    "picklists": {
      "fieldDependencies": [
        {
          "object": "Vehicle__c",
          "dependentField": "Gears__c",
          "controllingField": "Transmission__c"
        }
      ]
    }
  }
}
```

Make sure there is no field dependency for `Vehicle__c.Gears__c`:

```json
{
  "$schema": "https://raw.githubusercontent.com/amtrack/sfdx-browserforce-plugin/master/src/plugins/schema.json",
  "settings": {
    "picklists": {
      "fieldDependencies": [
        {
          "object": "Vehicle__c",
          "dependentField": "Gears__c",
          "controllingField": null
        }
      ]
    }
  }
}
```