### PR TITLE
feat: "Set Up and Enable High Velocity Sales"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Here is a full blown example showing most of the supported settings in action:
     "deferSharingCalculation": {
       "suspend": true
     },
+    "highVelocitySalesSettings": {
+      "setUpAndEnable": true
+    },
     "homePageLayouts": {
       "homePageLayoutAssignments": [
         {

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,5 +2,5 @@
   "orgName": "Browserforce",
   "edition": "Developer",
   "language": "en_US",
-  "features": ["DeferSharingCalc"]
+  "features": ["DeferSharingCalc", "HighVelocitySales"]
 }

--- a/src/plugins/high-velocity-sales-settings/disable.json
+++ b/src/plugins/high-velocity-sales-settings/disable.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "highVelocitySalesSettings": {
+      "setUpAndEnable": false
+    }
+  }
+}

--- a/src/plugins/high-velocity-sales-settings/enable.json
+++ b/src/plugins/high-velocity-sales-settings/enable.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "highVelocitySalesSettings": {
+      "setUpAndEnable": true
+    }
+  }
+}

--- a/src/plugins/high-velocity-sales-settings/index.e2e-spec.ts
+++ b/src/plugins/high-velocity-sales-settings/index.e2e-spec.ts
@@ -1,0 +1,57 @@
+import * as assert from 'assert';
+import * as child from 'child_process';
+import * as path from 'path';
+import HighVelocitySalesSettings from '.';
+
+describe(HighVelocitySalesSettings.name, function() {
+  this.slow('30s');
+  this.timeout('2m');
+  it('should enable', () => {
+    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'enable.json'))
+    ]);
+    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
+    assert(
+      /to 'true'/.test(enableCmd.output.toString()),
+      enableCmd.output.toString()
+    );
+  });
+  it('should already be enabled', () => {
+    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.join(__dirname, 'enable.json')
+    ]);
+    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
+    assert(
+      /no action necessary/.test(enableCmd.output.toString()),
+      enableCmd.output.toString()
+    );
+  });
+  it('should disable', () => {
+    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'disable.json'))
+    ]);
+    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
+    assert(
+      /to 'false'/.test(disableCmd.output.toString()),
+      disableCmd.output.toString()
+    );
+  });
+  it('should already be disabled', () => {
+    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.join(__dirname, 'disable.json')
+    ]);
+    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
+    assert(
+      /no action necessary/.test(disableCmd.output.toString()),
+      disableCmd.output.toString()
+    );
+  });
+});

--- a/src/plugins/high-velocity-sales-settings/index.ts
+++ b/src/plugins/high-velocity-sales-settings/index.ts
@@ -1,0 +1,52 @@
+import { BrowserforcePlugin } from '../../plugin';
+import { HighVelocitySalesSetupPage } from './page';
+
+const MSG_NOT_AVAILABLE = `HighVelocitySales is not available in this organization.
+Please add 'HighVelocitySales' to your Scratch Org Features or purchase a license.`;
+
+export default class HighVelocitySalesSettings extends BrowserforcePlugin {
+  public async retrieve(definition?) {
+    const conn = this.org.getConnection();
+    const result = { setUpAndEnable: false };
+    try {
+      const settings = await conn.metadata.read(
+        'HighVelocitySalesSettings',
+        'HighVelocitySales'
+      );
+      result.setUpAndEnable =
+        settings['enableHighVelocitySalesSetup'] === 'true';
+    } catch (e) {
+      if (
+        /INVALID_TYPE: This type of metadata is not available for this organization/.test(
+          e
+        )
+      ) {
+        throw new Error(MSG_NOT_AVAILABLE);
+      } else {
+        throw e;
+      }
+    }
+    return result;
+  }
+
+  public async apply(config) {
+    if (config.setUpAndEnable) {
+      const page = new HighVelocitySalesSetupPage(
+        await this.browserforce.openPage(HighVelocitySalesSetupPage.getUrl())
+      );
+      await page.setUpAndEnable();
+    } else {
+      const conn = this.org.getConnection();
+      await disableHighVelocitySalesUsingMetadata(conn);
+    }
+  }
+}
+
+export async function disableHighVelocitySalesUsingMetadata(conn) {
+  const settings = {
+    fullName: 'HighVelocitySales',
+    enableHighVelocitySalesSetup: 'false',
+    enableHighVelocitySales: 'false'
+  };
+  await conn.metadata.update('HighVelocitySalesSettings', settings);
+}

--- a/src/plugins/high-velocity-sales-settings/page.ts
+++ b/src/plugins/high-velocity-sales-settings/page.ts
@@ -1,0 +1,23 @@
+import { throwPageErrors } from '../../browserforce';
+
+const SET_UP_AND_ENABLE_HVS_BUTTON = 'button.setupAndEnableButton';
+const ENABLE_TOGGLE = '#toggleHighVelocitySalesPref';
+
+export class HighVelocitySalesSetupPage {
+  private page;
+
+  constructor(page) {
+    this.page = page;
+  }
+
+  public static getUrl(): string {
+    return 'lightning/setup/HighVelocitySales/home';
+  }
+
+  public async setUpAndEnable() {
+    await this.page.waitForSelector(SET_UP_AND_ENABLE_HVS_BUTTON);
+    await this.page.click(SET_UP_AND_ENABLE_HVS_BUTTON);
+    await throwPageErrors(this.page);
+    await this.page.waitForSelector(ENABLE_TOGGLE);
+  }
+}

--- a/src/plugins/high-velocity-sales-settings/schema.json
+++ b/src/plugins/high-velocity-sales-settings/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/high-velocity-sales-settings/schema.json",
+  "title": "HighVelocitySalesSettings",
+  "description": "Due to a bug, High Velocity Sales needs to be set up and enabled initially using the UI.\nOnce set up, it can be configured using HighVelocitySalesSettings Metadata https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_highvelocitysalessettings.htm",
+  "type": "object",
+  "properties": {
+    "setUpAndEnable": {
+      "title": "Set Up and Enable High Velocity Sales",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -11,7 +11,10 @@ import * as security from './security';
 import * as picklists from './picklists';
 import * as recordTypes from './record-types';
 
+import * as highVelocitySalesSettings from './high-velocity-sales-settings';
+
 export {
+  highVelocitySalesSettings,
   recordTypes,
   picklists,
   deferSharingCalculation,

--- a/src/plugins/schema.json
+++ b/src/plugins/schema.json
@@ -7,6 +7,9 @@
   "properties": {
     "settings": {
       "properties": {
+        "highVelocitySalesSettings": {
+          "$ref": "./high-velocity-sales-settings/schema.json"
+        },
         "recordTypes": {
           "$ref": "./record-types/schema.json"
         },


### PR DESCRIPTION
Due to a bug, High Velocity Sales needs to be set up and enabled
initially using the UI.
Once set up, it can be configured using HighVelocitySalesSettings Metadata
https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_highvelocitysalessettings.htm

Fixes #375