### PR TITLE
feat: add emptyOrgRecycleBin to clean up space used by large amounts of records in the recycle bin

### DIFF
--- a/src/plugins/empty-org-recycle-bin/disable.json
+++ b/src/plugins/empty-org-recycle-bin/disable.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "emptyOrgRecycleBin": {
+      "enabled": false
+    }
+  }
+}

--- a/src/plugins/empty-org-recycle-bin/enable.json
+++ b/src/plugins/empty-org-recycle-bin/enable.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "emptyOrgRecycleBin": {
+      "enabled": true
+    }
+  }
+}

--- a/src/plugins/empty-org-recycle-bin/index.ts
+++ b/src/plugins/empty-org-recycle-bin/index.ts
@@ -1,0 +1,42 @@
+import { BrowserforcePlugin } from '../../plugin';
+
+const DELETE_EVENT_OBJECT = 'DeleteEvent';
+const LIST_VIEW_ALL_DELETE_EVENTS = 'AllDeleteEvents';
+const DELETE_EVENT_EMPTY_ALL_ACTION = 'DeleteEventEmptyAllAction';
+
+const PATHS = {
+  BASE: 'lightning/o/DeleteEvent/home'
+};
+
+const SELECTORS = {
+  EMPTY_BUTTON: '.modal-container .modal-footer button.uiButton:last-of-type'
+};
+
+export class EmptyOrgRecycleBin extends BrowserforcePlugin {
+  public async retrieve(definition?: Config): Promise<Config> {
+    return { enabled: false };
+  }
+
+  public async apply(config: Config): Promise<void> {
+    const deleteEventEmptyAllButtonSelector = `a.forceActionLink[title="${await this.determineDeleteEventEmptyAllActionLabel()}"]`;
+
+    const page = await this.browserforce.openPage(PATHS.BASE);
+    await page.waitForSelector(deleteEventEmptyAllButtonSelector);
+    await page.click(deleteEventEmptyAllButtonSelector);
+    await page.waitForSelector(SELECTORS.EMPTY_BUTTON);
+    await page.click(SELECTORS.EMPTY_BUTTON);
+  }
+
+  private async determineDeleteEventEmptyAllActionLabel(): Promise<string> {
+    const conn = this.org.getConnection();
+    const deleteEventListViewsUrl = `${conn.instanceUrl}/services/data/v${conn.getApiVersion()}/ui-api/list-ui/${DELETE_EVENT_OBJECT}`;
+    const deleteEventListViewsResponse = await conn.request(deleteEventListViewsUrl);
+    const allDeleteEventsListView = deleteEventListViewsResponse['lists'].filter((value) => value.apiName == LIST_VIEW_ALL_DELETE_EVENTS)[0];
+    const allDeleteEventsListViewId = allDeleteEventsListView['id'];
+    const allDeleteEventsListViewActionsUrl = `${conn.instanceUrl}/services/data/v${conn.getApiVersion()}/ui-api/actions/list-view/${allDeleteEventsListViewId}`;
+    const allDeleteEventsListViewActionsResponse = await conn.request(allDeleteEventsListViewActionsUrl);
+    const deleteEventEmptyAllEventsAction = allDeleteEventsListViewActionsResponse['actions'][allDeleteEventsListViewId]['actions'].filter((value) => value.apiName == DELETE_EVENT_EMPTY_ALL_ACTION)[0];
+
+    return deleteEventEmptyAllEventsAction.label;
+  }
+}

--- a/src/plugins/empty-org-recycle-bin/schema.json
+++ b/src/plugins/empty-org-recycle-bin/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/empty-org-recycle-bin/schema.json",
+  "title": "EmptyOrgRecycleBin Settings",
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "title": "Enable EmptyOrgRecycleBin",
+      "description": "The description you want to be displayed as toolip when the user is editing the configuration",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -14,7 +14,10 @@ import { Security as security } from './security';
 
 import { RelateContactToMultipleAccounts as relateContactToMultipleAccounts } from './relate-contact-to-multiple-accounts';
 
+import { EmptyOrgRecycleBin as emptyOrgRecycleBin } from './empty-org-recycle-bin';
+
 export {
+  emptyOrgRecycleBin,
   relateContactToMultipleAccounts,
   activitySettings,
   communities,

--- a/src/plugins/schema.json
+++ b/src/plugins/schema.json
@@ -7,6 +7,9 @@
   "properties": {
     "settings": {
       "properties": {
+        "emptyOrgRecycleBin": {
+          "$ref": "./empty-org-recycle-bin/schema.json"
+        },
         "relateContactToMultipleAccounts": {
           "$ref": "./relate-contact-to-multiple-accounts/schema.json"
         },


### PR DESCRIPTION
Adds a new plugin EmptyOrgRecycleBin that will navigate to the Recycle Bin Lightning Page (`/lightning/o/DeleteEvent/home`) and press the "Empty Org Recycle Bin" button.

As this does not represent a "setting" in Salesforce, the plugin will simply always return `{ enabled: false }` from its `retrieve()` method. To empty the org recycle bin, apply the following setting (with `enabled` set to `true`):
```
  "settings": {
    ...
    "emptyOrgRecycleBin": {
      "enabled": true
    }
    ...
  }
```
This will execute the plugins `apply` method and empty the recycle bin.