### PR TITLE
fix: Allow sharing recalculation to execute

### DIFF
--- a/src/plugins/defer-sharing-calculation/index.ts
+++ b/src/plugins/defer-sharing-calculation/index.ts
@@ -47,6 +47,7 @@ export class DeferSharingCalculation extends BrowserforcePlugin {
     await page.click(button);
     if (!config.suspend) {
       const refreshedPage = await this.browserforce.openPage(PATHS.BASE);
+      await page.waitForSelector(SELECTORS.RECALCULATE_BUTTON);
       await refreshedPage.click(SELECTORS.RECALCULATE_BUTTON);
     }
   }


### PR DESCRIPTION
After running the command I noticed that the sharing recalculation would not execute. I have added a wait step for the recalculation button ahead of clicking it. 