### PR TITLE
feat: email deliverability switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /tmp
 node_modules
 /.sfdx
+/.sf
 
 .vscode/settings.json

--- a/_templates/plugin/new/index.e2e-spec.ejs.t
+++ b/_templates/plugin/new/index.e2e-spec.ejs.t
@@ -4,7 +4,7 @@ to: src/plugins/<%= h.changeCase.paramCase(name) %>/index.e2e-spec.ts
 import * as assert from 'assert';
 import * as child from 'child_process';
 import * as path from 'path';
-import <%= h.changeCase.pascalCase(name) %> from '.';
+import { <%= h.changeCase.pascalCase(name) %> } from '.';
 
 describe(<%= h.changeCase.pascalCase(name) %>.name, function() {
   this.slow('30s');

--- a/src/plugins/email-deliverability/all.json
+++ b/src/plugins/email-deliverability/all.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "emailDeliverability": {
+      "accessLevel": "All email"
+    }
+  }
+}

--- a/src/plugins/email-deliverability/index.e2e-spec.ts
+++ b/src/plugins/email-deliverability/index.e2e-spec.ts
@@ -1,0 +1,94 @@
+import * as assert from 'assert';
+import * as child from 'child_process';
+import * as path from 'path';
+import { EmailDeliverability } from '.';
+
+describe(EmailDeliverability.name, function() {
+  this.slow('30s');
+  this.timeout('2m');
+  // Note order is important here, the scratch org will be created with all access set, I have placed last so if a scratch is reused at least it is in the same state
+  it('should set "no access"', () => {
+    const applyNoAccessCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'no-access.json'))
+    ]);
+    assert.deepStrictEqual(applyNoAccessCmd.status, 0, applyNoAccessCmd.output.toString());
+    assert(
+      /to '"No access"'/.test(applyNoAccessCmd.output.toString()),
+      applyNoAccessCmd.output.toString()
+    );
+  });
+  it('should already be set to "no access"', () => {
+    const applyNoAccessCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.join(__dirname, 'no-access.json')
+    ]);
+    assert.deepStrictEqual(applyNoAccessCmd.status, 0, applyNoAccessCmd.output.toString());
+    assert(
+      /no action necessary/.test(applyNoAccessCmd.output.toString()),
+      applyNoAccessCmd.output.toString()
+    );
+  });
+  it('should set "syetem only"', () => {
+    const systemEmailCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'system.json'))
+    ]);
+    assert.deepStrictEqual(systemEmailCmd.status, 0, systemEmailCmd.output.toString());
+    assert(
+      /to '"System email only"'/.test(systemEmailCmd.output.toString()),
+      systemEmailCmd.output.toString()
+    );
+  });
+  it('should already be set to no access', () => {
+    const systemEmailCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.join(__dirname, 'system.json')
+    ]);
+    assert.deepStrictEqual(systemEmailCmd.status, 0, systemEmailCmd.output.toString());
+    assert(
+      /no action necessary/.test(systemEmailCmd.output.toString()),
+      systemEmailCmd.output.toString()
+    );
+  });
+  it('should apply all email', () => {
+    const applyAllCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.resolve(path.join(__dirname, 'all.json'))
+    ]);
+    assert.deepStrictEqual(applyAllCmd.status, 0, applyAllCmd.output.toString());
+    assert(
+      /to '"All email"'/.test(applyAllCmd.output.toString()),
+      applyAllCmd.output.toString()
+    );
+  });
+  it('should already be have all enabled', () => {
+    const applyAllCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.join(__dirname, 'all.json')
+    ]);
+    assert.deepStrictEqual(applyAllCmd.status, 0, applyAllCmd.output.toString());
+    assert(
+      /no action necessary/.test(applyAllCmd.output.toString()),
+      applyAllCmd.output.toString()
+    );
+  });
+  it('should error on invalid input', () => {
+    const systemEmailCmd = child.spawnSync(path.resolve('bin', 'run'), [
+      'browserforce:apply',
+      '-f',
+      path.join(__dirname, 'invalid.json')
+    ]);
+    assert.notDeepStrictEqual(systemEmailCmd.status, 0, systemEmailCmd.output.toString());
+    assert(
+      /Invalid email access level/.test(systemEmailCmd.output.toString()),
+      systemEmailCmd.output.toString()
+    );
+  });
+});

--- a/src/plugins/email-deliverability/index.ts
+++ b/src/plugins/email-deliverability/index.ts
@@ -1,0 +1,49 @@
+import { BrowserforcePlugin } from '../../plugin';
+
+const PATHS = {
+  BASE: 'email-admin/editOrgEmailSettings.apexp'
+};
+const SELECTORS = {
+  ACCESS_LEVEL: 'select[id$=":sendEmailAccessControlSelect"]',
+  CONFIRM_MESSAGE: 'span[id$=":successText"]',
+  SAVE_BUTTON: 'input[id$=":saveBtn"]'
+};
+const ACCESS_LEVEL_VALUES = new Map([
+  ['No access', '0',],
+  ['System email only', '1',],
+  ['All email', '2']
+]);
+
+type Config = {
+  accessLevel: string;
+};
+
+export class EmailDeliverability extends BrowserforcePlugin {
+  public async retrieve(definition?: Config): Promise<Config> {
+    if (!ACCESS_LEVEL_VALUES.has(definition.accessLevel)) {
+      throw new Error(`Invalid email access level ${definition.accessLevel}`);
+    }
+    const page = await this.browserforce.openPage(PATHS.BASE);
+    await page.waitForSelector(SELECTORS.ACCESS_LEVEL);
+    const selectedOptions = await page.$$eval(
+      `${SELECTORS.ACCESS_LEVEL} > option[selected]`,
+      options => options.map(option => option.textContent)
+    );
+    if (!selectedOptions) {
+      throw new Error('Selected access level not found...')
+    }
+    return {
+      accessLevel: selectedOptions[0]
+    };;
+  }
+
+  public async apply(config: Config): Promise<void> {
+    const page = await this.browserforce.openPage(PATHS.BASE);
+    await page.waitForSelector(SELECTORS.ACCESS_LEVEL);
+    await page.select(SELECTORS.ACCESS_LEVEL, ACCESS_LEVEL_VALUES.get(config.accessLevel));
+    await Promise.all([
+      page.waitForSelector(SELECTORS.CONFIRM_MESSAGE),
+      page.click(SELECTORS.SAVE_BUTTON)
+    ]);
+  }
+}

--- a/src/plugins/email-deliverability/invalid.json
+++ b/src/plugins/email-deliverability/invalid.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "emailDeliverability": {
+      "accessLevel": "Invalid"
+    }
+  }
+}

--- a/src/plugins/email-deliverability/no-access.json
+++ b/src/plugins/email-deliverability/no-access.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "emailDeliverability": {
+      "accessLevel": "No access"
+    }
+  }
+}

--- a/src/plugins/email-deliverability/schema.json
+++ b/src/plugins/email-deliverability/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/density-settings/schema.json",
+  "title": "Email Deliverability Settings",
+  "type": "object",
+  "properties": {
+    "accessLevel": {
+      "title": "Access Level",
+      "description": "Choose the email Deliverability Access Level required",
+      "type": "string",
+      "enum": ["No access", "System email only", "All email"]
+    }
+  }
+}

--- a/src/plugins/email-deliverability/system.json
+++ b/src/plugins/email-deliverability/system.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "emailDeliverability": {
+      "accessLevel": "System email only"
+    }
+  }
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -3,6 +3,7 @@ import { Communities as communities } from './communities';
 import { CustomerPortal as customerPortal } from './customer-portal';
 import { DeferSharingCalculation as deferSharingCalculation } from './defer-sharing-calculation';
 import { DensitySettings as densitySettings } from './density-settings';
+import { EmailDeliverability as emailDeliverability } from './email-deliverability';
 import { HighVelocitySalesSettings as highVelocitySalesSettings } from './high-velocity-sales-settings';
 import { HomePageLayouts as homePageLayouts } from './home-page-layouts';
 import { LightningExperienceSettings as lightningExperienceSettings } from './lightning-experience-settings';
@@ -21,6 +22,7 @@ export {
   customerPortal,
   deferSharingCalculation,
   densitySettings,
+  emailDeliverability,
   highVelocitySalesSettings,
   homePageLayouts,
   lightningExperienceSettings,

--- a/src/plugins/schema.json
+++ b/src/plugins/schema.json
@@ -22,6 +22,9 @@
         "deferSharingCalculation": {
           "$ref": "./defer-sharing-calculation/schema.json"
         },
+        "emailDeliverability": {
+          "$ref": "./email-deliverability/schema.json"
+        },
         "lightningExperienceSettings": {
           "$ref": "./lightning-experience-settings/schema.json"
         },


### PR DESCRIPTION
Adding changes for an email deliverability switch. Where each value (all, system and no access) can be specified.

I have also made a couple of smaller changes, including the .sf folder into the .gitignore as this just includes the details of the default scratch, I think moving away from the .sfdx folder and adding curly braces in the template for the e2e test, as it was throwing a linting error on my machine without.