### PR TITLE
fix: Sharing Recalculation Intermittent Error

### DIFF
--- a/src/plugins/defer-sharing-calculation/index.ts
+++ b/src/plugins/defer-sharing-calculation/index.ts
@@ -47,7 +47,7 @@ export class DeferSharingCalculation extends BrowserforcePlugin {
     await page.click(button);
     if (!config.suspend) {
       const refreshedPage = await this.browserforce.openPage(PATHS.BASE);
-      await page.waitForSelector(SELECTORS.RECALCULATE_BUTTON);
+      await refreshedPage.waitForSelector(SELECTORS.RECALCULATE_BUTTON);
       await refreshedPage.click(SELECTORS.RECALCULATE_BUTTON);
     }
   }


### PR DESCRIPTION
I was seeing an intermittent error on the recalculation, looking into the code it seems the wait was on the original page which will likely have already loaded the recalculate button. 