### PR TITLE
test: disable test for HighVelocitySalesSettings

### DIFF
--- a/src/plugins/high-velocity-sales-settings/index.e2e-spec.ts
+++ b/src/plugins/high-velocity-sales-settings/index.e2e-spec.ts
@@ -3,7 +3,7 @@ import * as child from 'child_process';
 import * as path from 'path';
 import { HighVelocitySalesSettings } from '.';
 
-describe(HighVelocitySalesSettings.name, function() {
+describe.skip(HighVelocitySalesSettings.name, function() {
   this.slow('30s');
   this.timeout('2m');
   it('should enable', () => {


### PR DESCRIPTION
In the Winter '23 Release (API v56.0) this license for the feature doesn't seem to be available in Scratch Orgs anymore.