### PR TITLE
fix: Enabling communities (Lightning Experience Sites) no longer requires specifying a domain name

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha": "10.2.0",
     "nyc": "15.1.0",
     "oclif": "3.6.1",
+    "rimraf": "^4.1.2",
     "ts-node": "10.9.1",
     "typescript": "4.9.4"
   },
@@ -52,7 +53,7 @@
   },
   "repository": "amtrack/sfdx-browserforce-plugin",
   "scripts": {
-    "build": "rm -rf lib && tsc -p . && oclif manifest",
+    "build": "rimraf lib && tsc -p . && oclif manifest",
     "develop": "bash scripts/develop.sh",
     "format": "npx prettier --write \"+(src|test)/**/*.+(ts|js|json)\"",
     "generate:plugin": "npx hygen plugin new",

--- a/src/plugins/communities/index.ts
+++ b/src/plugins/communities/index.ts
@@ -6,13 +6,11 @@ const PATHS = {
 const SELECTORS = {
   BASE: 'div.pbBody',
   ENABLE_CHECKBOX: 'input[id$=":enableNetworkPrefId"]',
-  DOMAIN_NAME_INPUT_TEXT: 'input[id$=":inputSubdomain"]',
   SAVE_BUTTON: 'input[id$=":saveId"]'
 };
 
 type Config = {
   enabled?: boolean;
-  domainName?: string;
 };
 
 export class Communities extends BrowserforcePlugin {
@@ -46,22 +44,13 @@ export class Communities extends BrowserforcePlugin {
       SELECTORS.ENABLE_CHECKBOX
     );
     await frameOrPage.click(SELECTORS.ENABLE_CHECKBOX);
-    const domainName = (
-      config.domainName ||
-      this.browserforce.getMyDomain() ||
-      `comm-${Math.random()
-        .toString(36)
-        .substr(2)}`
-    ).substring(0, 22);
-    await frameOrPage.waitForSelector(SELECTORS.DOMAIN_NAME_INPUT_TEXT);
-    await frameOrPage.type(SELECTORS.DOMAIN_NAME_INPUT_TEXT, domainName);
     page.on('dialog', async dialog => {
       await dialog.accept();
     });
     await frameOrPage.waitForSelector(SELECTORS.SAVE_BUTTON);
     await Promise.all([
-      page.waitForNavigation(),
-      frameOrPage.click(SELECTORS.SAVE_BUTTON)
+      frameOrPage.click(SELECTORS.SAVE_BUTTON),
+      page.waitForNavigation()
     ]);
   }
 }

--- a/src/plugins/communities/schema.json
+++ b/src/plugins/communities/schema.json
@@ -8,11 +8,6 @@
       "title": "Enable Communities",
       "description": "Warning: cannot be disabled once enabled",
       "type": "boolean"
-    },
-    "domainName": {
-      "title": "Optional domain name for communities (default: mydomain)",
-      "description": "Important: The domain name will be used in all of your communities and can’t be changed after you save it",
-      "type": "string"
     }
   }
 }


### PR DESCRIPTION
Also includes a minor change to allow building the plugin on Windows