### PR TITLE
test: simplify developing E2E tests

### DIFF
--- a/_templates/plugin/new/index.e2e-spec.ejs.t
+++ b/_templates/plugin/new/index.e2e-spec.ejs.t
@@ -2,59 +2,32 @@
 to: src/plugins/<%= h.changeCase.paramCase(name) %>/index.e2e-spec.ts
 ---
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
-import { <%= h.changeCase.pascalCase(name) %> } from '.';
+import { type Config, <%= h.changeCase.pascalCase(name) %> } from '.';
 
 describe(<%= h.changeCase.pascalCase(name) %>.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+  let plugin;
+  before(() => {
+    plugin = new <%= h.changeCase.pascalCase(name) %>(global.bf);
   });
-  it('should already be enabled', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'enable.json')
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+
+  const configEnabled: Config = {
+    enabled: true
+  };
+  const configDisabled: Config = {
+    enabled: true
+  };
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
   });
-  it('should disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should already be enabled', async () => {
+    const res = await plugin.run(configEnabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should already be disabled', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'disable.json')
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should disable', async () => {
+    await plugin.run(configDisabled);
+  });
+  it('should already be disabled', async () => {
+    const res = await plugin.run(configDisabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
 });

--- a/_templates/plugin/new/index.ejs.t
+++ b/_templates/plugin/new/index.ejs.t
@@ -13,7 +13,7 @@ const SELECTORS = {
   SAVE_BUTTON: 'input[id$=":save"]'
 };
 
-type Config = {
+export type Config = {
   enabled: boolean;
 };
 

--- a/_templates/plugin/new/index.ejs.t
+++ b/_templates/plugin/new/index.ejs.t
@@ -27,6 +27,7 @@ export class <%= h.changeCase.pascalCase(name) %> extends BrowserforcePlugin {
         (el: HTMLInputElement) => el.checked
       )
     };
+    await page.close();
     return response;
   }
 
@@ -44,5 +45,6 @@ export class <%= h.changeCase.pascalCase(name) %> extends BrowserforcePlugin {
       page.waitForSelector(SELECTORS.CONFIRM_MESSAGE),
       page.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "prepack": "yarn build",
     "prepare": "yarn build",
     "test": "nyc --reporter=lcov --reporter=text mocha --require ts-node/register \"test/**/*.test.ts\" \"src/**/*.test.ts\"",
-    "test:e2e": "mocha --require ts-node/register \"test/**/*.e2e-spec.ts\" \"src/**/*.e2e-spec.ts\""
+    "test:e2e": "mocha --require ts-node/register --slow 30s --timeout 2m --file test/e2e-setup.ts \"test/**/*.e2e-spec.ts\" \"src/**/*.e2e-spec.ts\""
   }
 }

--- a/src/commands/browserforce/apply.ts
+++ b/src/commands/browserforce/apply.ts
@@ -11,7 +11,7 @@ export class BrowserforceApply extends BrowserforceCommand {
   public static description = messages.getMessage('applyCommandDescription');
 
   public static examples = [
-    `$ sfdx browserforce:apply -f ./config/setup-admin-login-as-any.json --targetusername myOrg@example.com
+    `$ sfdx <%= command.id %> -f ./config/setup-admin-login-as-any.json --targetusername myOrg@example.com
   logging in... done
   Applying definition file ./config/setup-admin-login-as-any.json to org myOrg@example.com
   [Security] retrieving state... done

--- a/src/commands/browserforce/apply.ts
+++ b/src/commands/browserforce/apply.ts
@@ -7,7 +7,7 @@ const messages = Messages.loadMessages(
   'browserforce'
 );
 
-export default class BrowserforceApply extends BrowserforceCommand {
+export class BrowserforceApply extends BrowserforceCommand {
   public static description = messages.getMessage('applyCommandDescription');
 
   public static examples = [

--- a/src/commands/browserforce/apply.ts
+++ b/src/commands/browserforce/apply.ts
@@ -28,7 +28,7 @@ export default class BrowserforceApply extends BrowserforceCommand {
     );
     for (const setting of this.settings) {
       const driver = setting.Driver;
-      const instance = new driver(this.bf, this.org);
+      const instance = new driver(this.bf);
       this.ux.startSpinner(`[${driver.name}] retrieving state`);
       let state;
       try {

--- a/src/commands/browserforce/plan.ts
+++ b/src/commands/browserforce/plan.ts
@@ -13,7 +13,7 @@ export class BrowserforcePlanCommand extends BrowserforceCommand {
   public static description = messages.getMessage('planCommandDescription');
 
   public static examples = [
-    `$ sfdx browserforce:plan -f ./config/setup-admin-login-as-any.json --targetusername myOrg@example.com
+    `$ sfdx <%= command.id %> -f ./config/setup-admin-login-as-any.json --targetusername myOrg@example.com
   logging in... done
   Generating plan with definition file ./config/setup-admin-login-as-any.json from org myOrg@example.com
   [Security] retrieving state... done

--- a/src/commands/browserforce/plan.ts
+++ b/src/commands/browserforce/plan.ts
@@ -9,7 +9,7 @@ const messages = Messages.loadMessages(
   'browserforce'
 );
 
-export default class BrowserforcePlanCommand extends BrowserforceCommand {
+export class BrowserforcePlanCommand extends BrowserforceCommand {
   public static description = messages.getMessage('planCommandDescription');
 
   public static examples = [

--- a/src/commands/browserforce/plan.ts
+++ b/src/commands/browserforce/plan.ts
@@ -36,7 +36,7 @@ export default class BrowserforcePlanCommand extends BrowserforceCommand {
     };
     for (const setting of this.settings) {
       const driver = setting.Driver;
-      const instance = new driver(this.bf, this.org);
+      const instance = new driver(this.bf);
       this.ux.startSpinner(`[${driver.name}] retrieving state`);
       let driverState;
       try {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,12 +3,12 @@ import * as jsonMergePatch from 'json-merge-patch';
 import { Browserforce } from './browserforce';
 
 export abstract class BrowserforcePlugin {
-  protected org: Org;
   protected browserforce: Browserforce;
+  protected org: Org;
 
-  public constructor(browserforce: Browserforce, org: Org) {
+  public constructor(browserforce: Browserforce) {
     this.browserforce = browserforce;
-    this.org = org;
+    this.org = browserforce?.org;
   }
   public abstract retrieve(definition?: unknown): Promise<unknown>;
   public diff(state: unknown, definition: unknown): unknown {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,7 @@
 import { Org } from '@salesforce/core';
 import * as jsonMergePatch from 'json-merge-patch';
 import { Browserforce } from './browserforce';
+import { isEmpty } from './plugins/utils';
 
 export abstract class BrowserforcePlugin {
   protected browserforce: Browserforce;
@@ -15,4 +16,16 @@ export abstract class BrowserforcePlugin {
     return jsonMergePatch.generate(state, definition);
   }
   public abstract apply(plan: unknown): Promise<unknown>;
+  public async run(plan: unknown): Promise<unknown> {
+    const state = await this.retrieve(plan);
+    const diff = this.diff(state, plan);
+    const needsAction = !isEmpty(diff);
+    if (needsAction) {
+      const result = await this.apply(diff);
+      return result;
+    }
+    return {
+      message: 'no action necessary'
+    };
+  }
 }

--- a/src/plugins/activity-settings/index.e2e-spec.ts
+++ b/src/plugins/activity-settings/index.e2e-spec.ts
@@ -1,65 +1,37 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { ActivitySettings } from '.';
 
-describe(ActivitySettings.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable allowUsersToRelateMultipleContactsToTasksAndEvents', () => {
-    const enableManyWhoPrefCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable-many-who-pref.json'))
-    ]);
-    assert.deepStrictEqual(
-      enableManyWhoPrefCmd.status,
-      0,
-      enableManyWhoPrefCmd.output.toString()
-    );
-    assert.ok(
-      /'allowUsersToRelateMultipleContactsToTasksAndEvents' to 'true'/.test(
-        enableManyWhoPrefCmd.output.toString()
-      ),
-      enableManyWhoPrefCmd.output.toString()
-    );
+describe(ActivitySettings.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new ActivitySettings(global.bf);
   });
-  it('should already be enabled: allowUsersToRelateMultipleContactsToTasksAndEvents', () => {
-    const enableManyWhoPrefCmd2 = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable-many-who-pref.json'))
-    ]);
-    assert.deepStrictEqual(
-      enableManyWhoPrefCmd2.status,
-      0,
-      enableManyWhoPrefCmd2.output.toString()
-    );
-    assert.ok(
-      /no action necessary/.test(enableManyWhoPrefCmd2.output.toString()),
-      enableManyWhoPrefCmd2.output.toString()
-    );
-  });
-  it('should fail to disable allowUsersToRelateMultipleContactsToTasksAndEvents', () => {
-    const disableManyWhoPrefCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable-many-who-pref.json'))
-    ]);
-    assert.deepStrictEqual(
-      disableManyWhoPrefCmd.status,
-      1,
-      disableManyWhoPrefCmd.output.toString()
-    );
-    assert.ok(
-      /'allowUsersToRelateMultipleContactsToTasksAndEvents' to 'false'/.test(
-        disableManyWhoPrefCmd.output.toString()
-      ),
-      disableManyWhoPrefCmd.output.toString()
-    );
-    assert.ok(
-      /can only be disabled/.test(disableManyWhoPrefCmd.output.toString()),
-      disableManyWhoPrefCmd.output.toString()
-    );
+
+  describe('allowUsersToRelateMultipleContactsToTasksAndEvents', () => {
+    const configEnabled = {
+      allowUsersToRelateMultipleContactsToTasksAndEvents: true
+    };
+    const configDisabled = {
+      allowUsersToRelateMultipleContactsToTasksAndEvents: false
+    };
+
+    it('should enable', async () => {
+      await plugin.run(configEnabled);
+    });
+    it('should be enabled', async () => {
+      const res = await plugin.retrieve();
+      assert.deepStrictEqual(res, configEnabled);
+    });
+    it('should fail to disable', async () => {
+      let err;
+      try {
+        await plugin.apply(configDisabled);
+      } catch (e) {
+        err = e;
+      }
+      assert.throws(() => {
+        throw err;
+      }, /can only be disabled/);
+    });
   });
 });

--- a/src/plugins/activity-settings/index.ts
+++ b/src/plugins/activity-settings/index.ts
@@ -23,6 +23,7 @@ export class ActivitySettings extends BrowserforcePlugin {
         (el: HTMLInputElement) => el.checked
       )
     };
+    await page.close();
     return response;
   }
 
@@ -45,5 +46,6 @@ export class ActivitySettings extends BrowserforcePlugin {
       page.waitForNavigation(),
       page.click(SELECTORS.SUBMIT_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/communities/index.e2e-spec.ts
+++ b/src/plugins/communities/index.e2e-spec.ts
@@ -1,37 +1,35 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { Communities } from '.';
 
-describe.skip(Communities.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+describe.skip(Communities.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new Communities(global.bf);
   });
-  it('should fail to disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 1, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
-    assert.ok(
-      /cannot be disabled/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+
+  const configEnabled = {
+    enabled: true
+  };
+  const configDisabled = {
+    enabled: false
+  };
+
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
+  });
+  it('should be enabled', async () => {
+    const res = await plugin.run(configEnabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+  it('should fail to disable', async () => {
+    let err;
+    try {
+      await plugin.apply(configDisabled);
+    } catch (e) {
+      err = e;
+    }
+    assert.throws(() => {
+      throw err;
+    }, /cannot be disabled/);
   });
 });

--- a/src/plugins/communities/index.ts
+++ b/src/plugins/communities/index.ts
@@ -32,6 +32,7 @@ export class Communities extends BrowserforcePlugin {
         (el: HTMLInputElement) => el.checked
       );
     }
+    await page.close();
     return response;
   }
 
@@ -63,5 +64,6 @@ export class Communities extends BrowserforcePlugin {
       page.waitForNavigation(),
       frameOrPage.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/company-information/index.ts
+++ b/src/plugins/company-information/index.ts
@@ -30,6 +30,7 @@ export class CompanyInformation extends BrowserforcePlugin {
       throw new Error('No available existing value');
     }
     response.defaultCurrencyIsoCode = selectedOptions[0];
+    await page.close();
     return response;
   }
 
@@ -68,6 +69,7 @@ export class CompanyInformation extends BrowserforcePlugin {
         page.waitForNavigation(),
         page.click(SELECTORS.SAVE_BUTTON)
       ]);
+      await page.close();
     }
   }
 }

--- a/src/plugins/customer-portal/available-custom-objects/index.test.ts
+++ b/src/plugins/customer-portal/available-custom-objects/index.test.ts
@@ -29,7 +29,7 @@ const tests = [
 
 describe('CustomerPortalAvailableCustomObjects', () => {
   describe('diff()', () => {
-    const p = new CustomerPortalAvailableCustomObjects(null, null);
+    const p = new CustomerPortalAvailableCustomObjects(null);
     for (const t of tests) {
       it(t.description, () => {
         const actual = p.diff(t.source, t.target);

--- a/src/plugins/customer-portal/available-custom-objects/index.ts
+++ b/src/plugins/customer-portal/available-custom-objects/index.ts
@@ -90,7 +90,9 @@ export class CustomerPortalAvailableCustomObjects extends BrowserforcePlugin {
             (el: HTMLInputElement) => el.checked
           )
         });
+        await editPage.close();
       }
+      await page.close();
     }
     return response;
   }
@@ -157,7 +159,9 @@ export class CustomerPortalAvailableCustomObjects extends BrowserforcePlugin {
           frameOrPage.waitForNavigation(),
           frameOrPage.click(SELECTORS.SAVE_BUTTON)
         ]);
+        await editPage.close();
       }
+      await page.close();
     }
   }
 }

--- a/src/plugins/customer-portal/enabled/index.test.ts
+++ b/src/plugins/customer-portal/enabled/index.test.ts
@@ -24,7 +24,7 @@ const tests = [
 
 describe('CustomerPortalEnabled', () => {
   describe('diff()', () => {
-    const p = new CustomerPortalEnabled(null, null);
+    const p = new CustomerPortalEnabled(null);
     for (const t of tests) {
       it(t.description, () => {
         const actual = p.diff(t.source, t.target);

--- a/src/plugins/customer-portal/enabled/index.ts
+++ b/src/plugins/customer-portal/enabled/index.ts
@@ -42,6 +42,7 @@ export class CustomerPortalEnable extends BrowserforcePlugin {
         page.waitForNavigation(),
         page.click(SELECTORS.SAVE_BUTTON)
       ]);
+      await page.close();
     }
   }
 }

--- a/src/plugins/customer-portal/index.e2e-spec.ts
+++ b/src/plugins/customer-portal/index.e2e-spec.ts
@@ -5,82 +5,89 @@ import { CustomerPortalAvailableCustomObjects } from './available-custom-objects
 import { CustomerPortalEnable } from './enabled';
 import { CustomerPortalSetup } from './portals';
 
-describe(CustomerPortalEnable.name, function() {
-  this.slow('30s');
-  this.timeout('2m 30s');
-  const dir = path.resolve(path.join(__dirname, 'enabled'));
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'enable.json')
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
-  });
-  it('should already be enabled', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'enable.json')
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
-  });
-  it('should fail to disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'disable.json')
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 1, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
-    assert.ok(
-      /cannot be disabled/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
-  });
-});
-
-describe(CustomerPortalSetup.name, function() {
-  this.slow('30s');
-  this.timeout('2m 30s');
-  const dir = path.resolve(path.join(__dirname, 'portals'));
-  describe('portals', () => {
-    it('should fail to set portal admin user without permset', () => {
-      const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
-        'browserforce:apply',
-        '-f',
-        path.join(dir, 'set-portal-admin.json')
-      ]);
-      assert.deepStrictEqual(
-        setupPortalCmd.status,
-        1,
-        setupPortalCmd.output.toString()
-      );
-      assert.ok(
-        /changing 'portals' to .*"User User"/.test(
-          setupPortalCmd.output.toString()
-        ),
-        setupPortalCmd.output.toString()
-      );
-      assert.ok(
-        /This user has insufficient permissions to be a portal administrator/.test(
-          setupPortalCmd.output.toString()
-        ),
-        setupPortalCmd.output.toString()
-      );
+describe('CustomerPortal', () => {
+  describe(CustomerPortalEnable.name, function () {
+    let plugin;
+    before(() => {
+      plugin = new CustomerPortalEnable(global.bf);
     });
-    it('should setup user for portal', () => {
+
+    it('should enable', async () => {
+      await plugin.run(true);
+    });
+    it('should be enabled', async () => {
+      const res = await plugin.retrieve();
+      assert.deepStrictEqual(res, true);
+    });
+    it('should fail to disable', async () => {
+      let err;
+      try {
+        await plugin.run(false);
+      } catch (e) {
+        err = e;
+      }
+      assert.throws(() => {
+        throw err;
+      }, /cannot be disabled/);
+    });
+  });
+
+  describe(CustomerPortalSetup.name, function () {
+    let plugin;
+    before(() => {
+      plugin = new CustomerPortalSetup(global.bf);
+    });
+
+    const configSetPortalAdmin = [
+      {
+        name: 'Customer Portal',
+        adminUser: 'User User',
+        isSelfRegistrationActivated: true
+      }
+    ];
+    const configSetupPortal = [
+      {
+        name: 'Foo Portal',
+        oldName: 'Customer Portal',
+        description: 'Foo Portal',
+        adminUser: 'User User',
+        isSelfRegistrationActivated: true,
+        selfRegUserDefaultLicense: 'Customer Portal Manager Custom',
+        selfRegUserDefaultRole: 'User',
+        selfRegUserDefaultProfile: 'Customer Portal Manager Custom',
+        portalProfileMemberships: [
+          {
+            name: 'Customer Portal Manager Standard',
+            active: false
+          },
+          {
+            name: 'Dummy',
+            active: true
+          }
+        ]
+      }
+    ];
+    const configRevertPortal = [
+      {
+        name: 'Customer Portal',
+        oldName: 'Foo Portal',
+        description: 'Customer Portal',
+        isSelfRegistrationActivated: false
+      }
+    ];
+    const dir = path.resolve(path.join(__dirname, 'portals'));
+    it('should fail to set portal admin user without permset', async () => {
+      let err;
+      try {
+        await plugin.run(configSetPortalAdmin);
+      } catch (e) {
+        err = e;
+      }
+      assert.throws(() => {
+        throw err;
+      }, /This user has insufficient permissions to be a portal administrator/);
+    });
+    it('should set up user for portal', async () => {
       const sourceDeployCmd = child.spawnSync('sfdx', [
         'force:source:deploy',
         '-p',
@@ -97,7 +104,7 @@ describe(CustomerPortalSetup.name, function() {
         stdout.result &&
           stdout.result.deployedSource &&
           stdout.result.deployedSource.find(
-            source => source.fullName === 'Customer_Portal_Admin'
+            (source) => source.fullName === 'Customer_Portal_Admin'
           ),
         sourceDeployCmd.output.toString()
       );
@@ -116,147 +123,117 @@ describe(CustomerPortalSetup.name, function() {
         permSetAssignCmd.output.toString()
       );
     });
-    it('should setup portal', () => {
-      const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
-        'browserforce:apply',
-        '-f',
-        path.join(dir, 'setup-portal.json')
-      ]);
-      assert.deepStrictEqual(
-        setupPortalCmd.status,
-        0,
-        setupPortalCmd.output.toString()
-      );
-      assert.ok(
-        /changing 'portals' to .*"name":"Foo Portal"/.test(
-          setupPortalCmd.output.toString()
-        ),
-        setupPortalCmd.output.toString()
-      );
-      assert.ok(
-        /changing 'portals' to .*isSelfRegistrationActivated/.test(
-          setupPortalCmd.output.toString()
-        ),
-        setupPortalCmd.output.toString()
-      );
-      assert.ok(
-        /changing 'portals' to .*portalProfileMemberships/.test(
-          setupPortalCmd.output.toString()
-        ),
-        setupPortalCmd.output.toString()
-      );
+    it('should set up portal', async () => {
+      await plugin.run(configSetupPortal);
     });
-    it('should already be set up', () => {
-      const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
-        'browserforce:apply',
-        '-f',
-        path.join(dir, 'setup-portal.json')
+    it('portal should be set up', async () => {
+      const res = await plugin.run(configSetupPortal);
+      assert.deepStrictEqual(res, { message: 'no action necessary' });
+    });
+    it('should revert back', async () => {
+      await plugin.run(configRevertPortal);
+    });
+    it('should be reverted back', async () => {
+      const res = await plugin.run(configRevertPortal);
+      assert.deepStrictEqual(res, { message: 'no action necessary' });
+    });
+    it('should cleanup', async () => {
+      const conn = global.bf.org.getConnection();
+      await conn.metadata.delete('Profile', ['Dummy']);
+      const permSetUnassignCmd = child.spawnSync('sfdx', [
+        'force:data:record:delete',
+        '-s',
+        'PermissionSetAssignment',
+        '-w',
+        'PermissionSet.Name=Customer_Portal_Admin'
       ]);
       assert.deepStrictEqual(
-        setupPortalCmd.status,
+        permSetUnassignCmd.status,
         0,
-        setupPortalCmd.output.toString()
+        permSetUnassignCmd.output.toString()
       );
       assert.ok(
-        /no action necessary/.test(setupPortalCmd.output.toString()),
-        setupPortalCmd.output.toString()
+        /Successfully deleted record/.test(
+          permSetUnassignCmd.output.toString()
+        ),
+        permSetUnassignCmd.output.toString()
       );
+      await conn.metadata.delete('PermissionSet', ['Customer_Portal_Admin']);
     });
   });
-});
 
-describe(CustomerPortalAvailableCustomObjects.name, function() {
-  this.slow('30s');
-  this.timeout('2m 30s');
-  const dir = path.resolve(path.join(__dirname, 'available-custom-objects'));
-  it('should fail to make non-existent custom objects available for customer portal', () => {
-    const setupPortalCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'available.json')
-    ]);
-    assert.deepStrictEqual(
-      setupPortalCmd.status,
-      1,
-      setupPortalCmd.output.toString()
-    );
-    assert.ok(
-      /Could not find CustomObject/.test(setupPortalCmd.output.toString()),
-      setupPortalCmd.output.toString()
-    );
-  });
-  it('should deploy custom object', () => {
-    const sourceDeployCmd = child.spawnSync('sfdx', [
-      'force:source:deploy',
-      '-p',
-      path.join(dir, 'sfdx-source'),
-      '--json'
-    ]);
-    assert.deepStrictEqual(
-      sourceDeployCmd.status,
-      0,
-      sourceDeployCmd.output.toString()
-    );
-    const stdout = JSON.parse(sourceDeployCmd.stdout.toString());
-    assert.ok(
-      stdout.result &&
-        stdout.result.deployedSource &&
-        stdout.result.deployedSource.find(
-          source => source.fullName === 'Dummy__c'
-        ),
-      sourceDeployCmd.output.toString()
-    );
-  });
-  it('should make custom objects available for customer portal', () => {
-    const setupCustomObjectsCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'available.json')
-    ]);
-    assert.deepStrictEqual(
-      setupCustomObjectsCmd.status,
-      0,
-      setupCustomObjectsCmd.output.toString()
-    );
-    assert.ok(
-      /changing 'availableCustomObjects' to .*"available":true/.test(
-        setupCustomObjectsCmd.output.toString()
-      ),
-      setupCustomObjectsCmd.output.toString()
-    );
-  });
-  it('should have applied checkbox available for customer portal', () => {
-    const setupCustomObjectsCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'available.json')
-    ]);
-    assert.deepStrictEqual(
-      setupCustomObjectsCmd.status,
-      0,
-      setupCustomObjectsCmd.output.toString()
-    );
-    assert.ok(
-      /no action necessary/.test(setupCustomObjectsCmd.output.toString()),
-      setupCustomObjectsCmd.output.toString()
-    );
-  });
-  it('should make custom objects unavailable for customer portal', () => {
-    const setupCustomObjectsCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(dir, 'unavailable.json')
-    ]);
-    assert.deepStrictEqual(
-      setupCustomObjectsCmd.status,
-      0,
-      setupCustomObjectsCmd.output.toString()
-    );
-    assert.ok(
-      /changing 'availableCustomObjects' to .*"available":false/.test(
-        setupCustomObjectsCmd.output.toString()
-      ),
-      setupCustomObjectsCmd.output.toString()
-    );
+  describe(CustomerPortalAvailableCustomObjects.name, function () {
+    let plugin;
+    before(() => {
+      plugin = new CustomerPortalAvailableCustomObjects(global.bf);
+    });
+
+    const configAvailableCustomObjects = [
+      {
+        name: 'Dummy',
+        available: true
+      }
+    ];
+    const configNonAvailableCustomObjects = [
+      {
+        name: 'DummyXYZ',
+        available: true
+      }
+    ];
+    const configUnavailableCustomObjects = [
+      {
+        name: 'Dummy',
+        available: false
+      }
+    ];
+
+    const dir = path.resolve(path.join(__dirname, 'available-custom-objects'));
+    it('should fail to make non-existent custom objects available for customer portal', async () => {
+      let err;
+      try {
+        await plugin.run(configNonAvailableCustomObjects);
+      } catch (e) {
+        err = e;
+      }
+      assert.throws(() => {
+        throw err;
+      }, /Could not find CustomObject/);
+    });
+    it('should deploy custom object', () => {
+      const sourceDeployCmd = child.spawnSync('sfdx', [
+        'force:source:deploy',
+        '-p',
+        path.join(dir, 'sfdx-source'),
+        '--json'
+      ]);
+      assert.deepStrictEqual(
+        sourceDeployCmd.status,
+        0,
+        sourceDeployCmd.output.toString()
+      );
+      const stdout = JSON.parse(sourceDeployCmd.stdout.toString());
+      assert.ok(
+        stdout.result &&
+          stdout.result.deployedSource &&
+          stdout.result.deployedSource.find(
+            (source) => source.fullName === 'Dummy__c'
+          ),
+        sourceDeployCmd.output.toString()
+      );
+    });
+    it('should make custom objects available for customer portal', async () => {
+      await plugin.run(configAvailableCustomObjects);
+    });
+    it('should have applied checkbox available for customer portal', async () => {
+      const res = await plugin.run(configAvailableCustomObjects);
+      assert.deepStrictEqual(res, { message: 'no action necessary' });
+    });
+    it('should make custom objects unavailable for customer portal', async () => {
+      await plugin.run(configUnavailableCustomObjects);
+    });
+    it('should remove the CustomObject', async () => {
+      const conn = global.bf.org.getConnection();
+      await conn.metadata.delete('CustomObject', ['Dummy__c']);
+    });
   });
 });

--- a/src/plugins/customer-portal/index.test.ts
+++ b/src/plugins/customer-portal/index.test.ts
@@ -73,7 +73,7 @@ const tests = [
 
 describe('CustomerPortal', () => {
   describe('diff()', () => {
-    const p = new CustomerPortal(null, null);
+    const p = new CustomerPortal(null);
     for (const t of tests) {
       it(t.description, () => {
         const actual = p.diff(t.source, t.target);

--- a/src/plugins/customer-portal/index.ts
+++ b/src/plugins/customer-portal/index.ts
@@ -21,7 +21,7 @@ type Config = {
 
 export class CustomerPortal extends BrowserforcePlugin {
   public async retrieve(definition?: Config): Promise<Config> {
-    const pluginEnable = new CustomerPortalEnable(this.browserforce, this.org);
+    const pluginEnable = new CustomerPortalEnable(this.browserforce);
     const response = {
       enabled: false,
       portals: [],
@@ -30,32 +30,26 @@ export class CustomerPortal extends BrowserforcePlugin {
     response.enabled = await pluginEnable.retrieve(definition.enabled);
     if (response.enabled) {
       if (definition.portals) {
-        const pluginSetup = new CustomerPortalSetup(
-          this.browserforce,
-          this.org
-        );
+        const pluginSetup = new CustomerPortalSetup(this.browserforce);
         response.portals = await pluginSetup.retrieve(definition.portals);
       }
       if (definition.availableCustomObjects) {
-        const pluginAvailableCustomObjects = new CustomerPortalAvailableCustomObjects(
-          this.browserforce,
-          this.org
-        );
-        response.availableCustomObjects = await pluginAvailableCustomObjects.retrieve(
-          definition.availableCustomObjects
-        );
+        const pluginAvailableCustomObjects =
+          new CustomerPortalAvailableCustomObjects(this.browserforce);
+        response.availableCustomObjects =
+          await pluginAvailableCustomObjects.retrieve(
+            definition.availableCustomObjects
+          );
       }
     }
     return response;
   }
 
   public diff(state: Config, definition: Config): Config {
-    const pluginEnable = new CustomerPortalEnable(null, null);
-    const pluginSetup = new CustomerPortalSetup(null, null);
-    const pluginAvailableCustomObjects = new CustomerPortalAvailableCustomObjects(
-      null,
-      null
-    );
+    const pluginEnable = new CustomerPortalEnable(null);
+    const pluginSetup = new CustomerPortalSetup(null);
+    const pluginAvailableCustomObjects =
+      new CustomerPortalAvailableCustomObjects(null);
     const response = {
       enabled: pluginEnable.diff(state.enabled, definition.enabled),
       portals: pluginSetup.diff(state.portals, definition.portals),
@@ -69,21 +63,16 @@ export class CustomerPortal extends BrowserforcePlugin {
 
   public async apply(config: Config): Promise<void> {
     if (config.enabled !== undefined) {
-      const pluginEnable = new CustomerPortalEnable(
-        this.browserforce,
-        this.org
-      );
+      const pluginEnable = new CustomerPortalEnable(this.browserforce);
       await pluginEnable.apply(config.enabled);
     }
     if (config.portals && config.portals.length) {
-      const pluginSetup = new CustomerPortalSetup(this.browserforce, this.org);
+      const pluginSetup = new CustomerPortalSetup(this.browserforce);
       await pluginSetup.apply(config.portals);
     }
     if (config.availableCustomObjects) {
-      const pluginAvailableCustomObjects = new CustomerPortalAvailableCustomObjects(
-        this.browserforce,
-        this.org
-      );
+      const pluginAvailableCustomObjects =
+        new CustomerPortalAvailableCustomObjects(this.browserforce);
       await pluginAvailableCustomObjects.apply(config.availableCustomObjects);
     }
   }

--- a/src/plugins/customer-portal/portals/index.test.ts
+++ b/src/plugins/customer-portal/portals/index.test.ts
@@ -128,7 +128,7 @@ const tests = [
 
 describe('CustomerPortalSetup', () => {
   describe('diff()', () => {
-    const p = new CustomerPortalSetup(null, null);
+    const p = new CustomerPortalSetup(null);
     for (const t of tests) {
       it(t.description, () => {
         const actual = p.diff(t.source, t.target);

--- a/src/plugins/customer-portal/portals/index.ts
+++ b/src/plugins/customer-portal/portals/index.ts
@@ -86,6 +86,7 @@ export class CustomerPortalSetup extends BrowserforcePlugin {
         `#${SELECTORS.PORTAL_SELF_REG_USER_DEFAULT_PROFILE_ID}`,
         (el: HTMLSelectElement) => el.selectedOptions[0].text
       );
+      await portalPage.close();
       // portalProfileMemberships
       const portalProfilePage = await this.browserforce.openPage(
         `${PATHS.PORTAL_PROFILE_MEMBERSHIP}?portalId=${portal._id}&setupid=CustomerSuccessPortalSettings`
@@ -117,7 +118,9 @@ export class CustomerPortalSetup extends BrowserforcePlugin {
         });
       }
       portal.portalProfileMemberships = portalProfileMemberships;
+      await portalProfilePage.close();
     }
+    await page.close();
     return response;
   }
 
@@ -279,7 +282,9 @@ export class CustomerPortalSetup extends BrowserforcePlugin {
             portalProfilePage.waitForNavigation(),
             portalProfilePage.click(SELECTORS.SAVE_BUTTON)
           ]);
+          await portalProfilePage.close();
         }
+        await page.close();
       }
     }
   }

--- a/src/plugins/customer-portal/portals/index.ts
+++ b/src/plugins/customer-portal/portals/index.ts
@@ -127,8 +127,9 @@ export class CustomerPortalSetup extends BrowserforcePlugin {
   public diff(source: Config, target: Config): Config {
     const response = [];
     if (source && target) {
-      for (const portal of target) {
-        let sourcePortal = source.find(p => p.name === portal.name);
+      for (const plannedPortal of target) {
+        const portal = JSON.parse(JSON.stringify(plannedPortal));
+        let sourcePortal = source.find((p) => p.name === portal.name);
         if (portal.oldName && !sourcePortal) {
           // fallback to old name of portal
           sourcePortal = source.find(p => p.name === portal.oldName);

--- a/src/plugins/defer-sharing-calculation/index.e2e-spec.ts
+++ b/src/plugins/defer-sharing-calculation/index.e2e-spec.ts
@@ -3,9 +3,17 @@ import * as child from 'child_process';
 import * as path from 'path';
 import { DeferSharingCalculation } from '.';
 
-describe(DeferSharingCalculation.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
+describe(DeferSharingCalculation.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new DeferSharingCalculation(global.bf);
+  });
+  const configSuspend = {
+    suspend: true
+  };
+  const configResume = {
+    suspend: false
+  };
   it('should assign the user defer sharing permissions', () => {
     const sourceDeployCmd = child.spawnSync('sfdx', [
       'force:source:deploy',
@@ -42,54 +50,47 @@ describe(DeferSharingCalculation.name, function() {
       permSetAssignCmd.output.toString()
     );
   });
-  it('should suspend', () => {
-    const suspendCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'suspend.json'))
-    ]);
-    assert.deepStrictEqual(suspendCmd.status, 0, suspendCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(suspendCmd.output.toString()),
-      suspendCmd.output.toString()
-    );
+  it('should suspend', async () => {
+    await plugin.run(configSuspend);
   });
-  it('should already be suspended', () => {
-    const suspendCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'suspend.json')
-    ]);
-    assert.deepStrictEqual(suspendCmd.status, 0, suspendCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(suspendCmd.output.toString()),
-      suspendCmd.output.toString()
-    );
+  it('should already be suspended', async () => {
+    const res = await plugin.run(configSuspend);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should resume', () => {
-    const resumeCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'resume.json'))
-    ]);
-    assert.deepStrictEqual(resumeCmd.status, 0, resumeCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(resumeCmd.output.toString()),
-      resumeCmd.output.toString()
-    );
+  it('should resume', async () => {
+    await plugin.run(configResume);
   });
-  it('should already be resumed', () => {
-    const resumeCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'resume.json')
+  it('should already be resumed', async () => {
+    let err;
+    let res;
+    try {
+      res = await plugin.run(configResume);
+    } catch (e) {
+      err = e;
+      assert.throws(() => {
+        throw err;
+      }, /Sharing recalculation is currently in progress, please wait until this has completed to plan/);
+    }
+    if (!err) {
+      assert.deepStrictEqual(res, { message: 'no action necessary' });
+    }
+  });
+  it('should delete the PermissionSetAssignment', async () => {
+    const permSetUnassignCmd = child.spawnSync('sfdx', [
+      'force:data:record:delete',
+      '-s',
+      'PermissionSetAssignment',
+      '-w',
+      'PermissionSet.Name=Defer_Sharing'
     ]);
+    assert.deepStrictEqual(
+      permSetUnassignCmd.status,
+      0,
+      permSetUnassignCmd.output.toString()
+    );
     assert.ok(
-      /no action necessary/.test(resumeCmd.output.toString()) ||
-        /Sharing recalculation is currently in progress, please wait until this has completed to plan/.test(
-          resumeCmd.output.toString()
-        ),
-      resumeCmd.output.toString()
+      /Successfully deleted record/.test(permSetUnassignCmd.output.toString()),
+      permSetUnassignCmd.output.toString()
     );
   });
 });

--- a/src/plugins/defer-sharing-calculation/index.ts
+++ b/src/plugins/defer-sharing-calculation/index.ts
@@ -32,6 +32,7 @@ export class DeferSharingCalculation extends BrowserforcePlugin {
         'Sharing recalculation is currently in progress, please wait until this has completed to plan'
       );
     }
+    await page.close();
     return {
       suspend: isSuspendDisabled
     };
@@ -44,14 +45,15 @@ export class DeferSharingCalculation extends BrowserforcePlugin {
       : SELECTORS.RESUME_BUTTON;
     await page.waitForSelector(button);
     await Promise.all([page.waitForNavigation(), page.click(button)]);
+    await page.close();
     if (!config.suspend) {
-      await page.close();
       const refreshedPage = await this.browserforce.openPage(PATHS.BASE);
       await refreshedPage.waitForSelector(SELECTORS.RECALCULATE_BUTTON);
       await Promise.all([
         refreshedPage.waitForNavigation(),
         refreshedPage.click(SELECTORS.RECALCULATE_BUTTON)
       ]);
+      await refreshedPage.close();
     }
   }
 }

--- a/src/plugins/density-settings/index.e2e-spec.ts
+++ b/src/plugins/density-settings/index.e2e-spec.ts
@@ -1,73 +1,29 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { DensitySettings } from '.';
 
-describe(DensitySettings.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should set to Compact', () => {
-    const setCompactCommand = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'compact.json'))
-    ]);
-    assert.deepStrictEqual(
-      setCompactCommand.status,
-      0,
-      setCompactCommand.output.toString()
-    );
-    assert.ok(
-      /to '"Compact"'/.test(setCompactCommand.output.toString()),
-      setCompactCommand.output.toString()
-    );
+describe(DensitySettings.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new DensitySettings(global.bf);
   });
-  it('should already be set to Compact', () => {
-    const setCompactCommand2 = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'compact.json'))
-    ]);
-    assert.deepStrictEqual(
-      setCompactCommand2.status,
-      0,
-      setCompactCommand2.output.toString()
-    );
-    assert.ok(
-      /no action necessary/.test(setCompactCommand2.output.toString()),
-      setCompactCommand2.output.toString()
-    );
+
+  const configComfy = {
+    density: 'Comfy'
+  };
+  const configCompact = { density: 'Compact' };
+
+  it('should set to Compact', async () => {
+    await plugin.run(configCompact);
   });
-  it('should set to Comfy', () => {
-    const setComfyCommand = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'comfy.json'))
-    ]);
-    assert.deepStrictEqual(
-      setComfyCommand.status,
-      0,
-      setComfyCommand.output.toString()
-    );
-    assert.ok(
-      /to '"Comfy"'/.test(setComfyCommand.output.toString()),
-      setComfyCommand.output.toString()
-    );
+  it('should be set to Compact', async () => {
+    const res = await plugin.retrieve();
+    assert.deepStrictEqual(res, configCompact);
   });
-  it('should already be set to Comfy', () => {
-    const setComfyCommand2 = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'comfy.json'))
-    ]);
-    assert.deepStrictEqual(
-      setComfyCommand2.status,
-      0,
-      setComfyCommand2.output.toString()
-    );
-    assert.ok(
-      /no action necessary/.test(setComfyCommand2.output.toString()),
-      setComfyCommand2.output.toString()
-    );
+  it('should set to Comfy', async () => {
+    await plugin.apply(configComfy);
+  });
+  it('should be set to Comfy', async () => {
+    const res = await plugin.retrieve();
+    assert.deepStrictEqual(res, configComfy);
   });
 });

--- a/src/plugins/density-settings/index.ts
+++ b/src/plugins/density-settings/index.ts
@@ -24,7 +24,8 @@ export class DensitySettings extends BrowserforcePlugin {
   public async retrieve(): Promise<Config> {
     const page = await this.browserforce.openPage(PATHS.BASE);
     const densities = await this.getDensities(page);
-    const selected = densities.find(input => input.checked);
+    const selected = densities.find((input) => input.checked);
+    await page.close();
     return {
       density: selected?.value
     };
@@ -33,6 +34,7 @@ export class DensitySettings extends BrowserforcePlugin {
   public async apply(config: Config): Promise<void> {
     const page = await this.browserforce.openPage(PATHS.BASE);
     await this.setDensity(page, config.density);
+    await page.close();
   }
 
   async getDensities(page: Page): Promise<Density[]> {

--- a/src/plugins/email-deliverability/index.ts
+++ b/src/plugins/email-deliverability/index.ts
@@ -29,6 +29,7 @@ export class EmailDeliverability extends BrowserforcePlugin {
       `${SELECTORS.ACCESS_LEVEL} > option[selected]`,
       options => options.map(option => option.textContent)
     );
+    await page.close();
     if (!selectedOptions) {
       throw new Error('Selected access level not found...')
     }
@@ -45,5 +46,6 @@ export class EmailDeliverability extends BrowserforcePlugin {
       page.waitForSelector(SELECTORS.CONFIRM_MESSAGE),
       page.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/email-deliverability/index.ts
+++ b/src/plugins/email-deliverability/index.ts
@@ -20,9 +20,6 @@ type Config = {
 
 export class EmailDeliverability extends BrowserforcePlugin {
   public async retrieve(definition?: Config): Promise<Config> {
-    if (!ACCESS_LEVEL_VALUES.has(definition.accessLevel)) {
-      throw new Error(`Invalid email access level ${definition.accessLevel}`);
-    }
     const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitForSelector(SELECTORS.ACCESS_LEVEL);
     const selectedOptions = await page.$$eval(
@@ -39,6 +36,9 @@ export class EmailDeliverability extends BrowserforcePlugin {
   }
 
   public async apply(config: Config): Promise<void> {
+    if (!ACCESS_LEVEL_VALUES.has(config.accessLevel)) {
+      throw new Error(`Invalid email access level ${config.accessLevel}`);
+    }
     const page = await this.browserforce.openPage(PATHS.BASE);
     await page.waitForSelector(SELECTORS.ACCESS_LEVEL);
     await page.select(SELECTORS.ACCESS_LEVEL, ACCESS_LEVEL_VALUES.get(config.accessLevel));

--- a/src/plugins/high-velocity-sales-settings/index.e2e-spec.ts
+++ b/src/plugins/high-velocity-sales-settings/index.e2e-spec.ts
@@ -1,57 +1,31 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { HighVelocitySalesSettings } from '.';
 
-describe(HighVelocitySalesSettings.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+describe(HighVelocitySalesSettings.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new HighVelocitySalesSettings(global.bf);
   });
-  it('should already be enabled', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'enable.json')
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+
+  const configEnabled = {
+    setUpAndEnable: true
+  };
+  const configDisabled = {
+    setUpAndEnable: false
+  };
+
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
   });
-  it('should disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should already be enabled', async () => {
+    const res = await plugin.run(configEnabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should already be disabled', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'disable.json')
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should disable', async () => {
+    await plugin.run(configDisabled);
+  });
+  it('should already be disabled', async () => {
+    const res = await plugin.run(configDisabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
 });

--- a/src/plugins/high-velocity-sales-settings/page.ts
+++ b/src/plugins/high-velocity-sales-settings/page.ts
@@ -20,5 +20,6 @@ export class HighVelocitySalesSetupPage {
     await this.page.click(SET_UP_AND_ENABLE_HVS_BUTTON);
     await throwPageErrors(this.page);
     await this.page.waitForSelector(ENABLE_TOGGLE);
+    await this.page.close();
   }
 }

--- a/src/plugins/home-page-layouts/index.e2e-spec.ts
+++ b/src/plugins/home-page-layouts/index.e2e-spec.ts
@@ -1,48 +1,48 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { HomePageLayouts } from '.';
 
-describe(HomePageLayouts.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should assign the home page default', () => {
-    const assignHomePageDefaultCmd = child.spawnSync(
-      path.resolve('bin', 'run'),
-      [
-        'browserforce:apply',
-        '-f',
-        path.resolve(path.join(__dirname, 'home-page-default.json'))
-      ]
-    );
-    assert.deepStrictEqual(
-      assignHomePageDefaultCmd.status,
-      0,
-      assignHomePageDefaultCmd.output.toString()
-    );
-    assert.ok(
-      /'\[{"profile":"Standard User","layout":""},{"profile":"System Administrator","layout":""}\]'/.test(
-        assignHomePageDefaultCmd.output.toString()
-      ),
-      assignHomePageDefaultCmd.output.toString()
-    );
+describe(HomePageLayouts.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new HomePageLayouts(global.bf);
   });
-  it('should assign the org default', () => {
-    const assignOrgDefaultCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'org-default.json'))
-    ]);
-    assert.deepStrictEqual(
-      assignOrgDefaultCmd.status,
-      0,
-      assignOrgDefaultCmd.output.toString()
-    );
-    assert.ok(
-      /'\[{"profile":"Standard User","layout":"DE Default"},{"profile":"System Administrator","layout":"DE Default"}\]'/.test(
-        assignOrgDefaultCmd.output.toString()
-      ),
-      assignOrgDefaultCmd.output.toString()
-    );
+
+  const configPageDefault = {
+    homePageLayoutAssignments: [
+      {
+        profile: 'Standard User',
+        layout: ''
+      },
+      {
+        profile: 'System Administrator',
+        layout: ''
+      }
+    ]
+  };
+  const configOrgDefault = {
+    homePageLayoutAssignments: [
+      {
+        profile: 'Standard User',
+        layout: 'DE Default'
+      },
+      {
+        profile: 'System Administrator',
+        layout: 'DE Default'
+      }
+    ]
+  };
+  it('should assign some layouts', async () => {
+    await plugin.run(configPageDefault);
+  });
+  it('should be assigned', async () => {
+    const res = await plugin.run(configPageDefault);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+  it('should unassign some layouts', async () => {
+    await plugin.apply(configOrgDefault);
+  });
+  it('should be unassigned', async () => {
+    const res = await plugin.run(configOrgDefault);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
 });

--- a/src/plugins/home-page-layouts/index.ts
+++ b/src/plugins/home-page-layouts/index.ts
@@ -59,6 +59,7 @@ export class HomePageLayouts extends BrowserforcePlugin {
         layout: layouts[i]
       });
     }
+    await page.close();
     return {
       homePageLayoutAssignments
     };
@@ -120,5 +121,6 @@ export class HomePageLayouts extends BrowserforcePlugin {
       page.waitForNavigation(),
       page.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/lightning-experience-settings/index.e2e-spec.ts
+++ b/src/plugins/lightning-experience-settings/index.e2e-spec.ts
@@ -1,59 +1,28 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { LightningExperienceSettings } from '.';
 
-describe(LightningExperienceSettings.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should activate LightningLite theme', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'activate-lightning-lite.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'activeThemeName' to '"LightningLite"'/.test(
-        cmd.output.toString()
-      ),
-      cmd.output.toString()
-    );
-  });
-  it('LightningLite theme should already be activated', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'activate-lightning-lite.json')
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
-  });
-  it('should activate Lightning theme', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'activate-lightning.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'activeThemeName' to '"Lightning"'/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
-  });
-  it('Lightning theme should already be activated', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'activate-lightning.json')
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+describe(LightningExperienceSettings.name, function () {
+  describe('activeThemeName', () => {
+    let plugin;
+    before(() => {
+      plugin = new LightningExperienceSettings(global.bf);
+    });
+
+    const configLightningLite = { activeThemeName: 'LightningLite' };
+    const configLightning = { activeThemeName: 'Lightning' };
+    it('should activate LightningLite theme', async () => {
+      await plugin.run(configLightningLite);
+    });
+    it('LightningLite theme should already be activated', async () => {
+      const state = await plugin.retrieve();
+      assert.deepStrictEqual(state, configLightningLite);
+    });
+    it('should activate Lightning theme', async () => {
+      await plugin.apply(configLightning);
+    });
+    it('Lightning theme should already be activated', async () => {
+      const state = await plugin.retrieve();
+      assert.deepStrictEqual(state, configLightning);
+    });
   });
 });

--- a/src/plugins/lightning-experience-settings/index.ts
+++ b/src/plugins/lightning-experience-settings/index.ts
@@ -30,13 +30,14 @@ export class LightningExperienceSettings extends BrowserforcePlugin {
     const response = {
       activeThemeName: activeTheme.developerName
     };
+    await page.close();
     return response;
   }
 
   public async apply(config: Config): Promise<void> {
     const page = await this.browserforce.openPage(PATHS.BASE);
-
     await this.setActiveTheme(page, config.activeThemeName);
+    await page.close();
   }
 
   async getThemeData(page: Page): Promise<Theme[]> {

--- a/src/plugins/opportunity-splits/index.e2e-spec.ts
+++ b/src/plugins/opportunity-splits/index.e2e-spec.ts
@@ -4,8 +4,17 @@ import * as path from 'path';
 import { OpportunitySplits } from '.';
 
 describe(OpportunitySplits.name, function () {
-  this.slow('30s');
-  this.timeout('2m');
+  let plugin;
+  before(() => {
+    plugin = new OpportunitySplits(global.bf);
+  });
+
+  const configEnabled = {
+    enabled: true
+  };
+  const configDisabled = {
+    enabled: false
+  };
   it('should enable Opportunity Teams as prerequisite', () => {
     const sourceDeployCmd = child.spawnSync('sfdx', [
       'force:source:deploy',
@@ -19,52 +28,18 @@ describe(OpportunitySplits.name, function () {
       sourceDeployCmd.output.toString()
     );
   });
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
   });
-  it('should already be enabled', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'enable.json')
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+  it('should be enabled', async () => {
+    const state = await plugin.retrieve();
+    assert.deepStrictEqual(state, configEnabled);
   });
-  it('should disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should disable', async () => {
+    await plugin.apply(configDisabled);
   });
-  it('should already be disabled', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'disable.json')
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should be disabled', async () => {
+    const state = await plugin.retrieve();
+    assert.deepStrictEqual(state, configDisabled);
   });
 });

--- a/src/plugins/opportunity-splits/index.ts
+++ b/src/plugins/opportunity-splits/index.ts
@@ -1,3 +1,4 @@
+import { Page } from 'puppeteer';
 import { BrowserforcePlugin } from '../../plugin';
 import { OverviewPage } from './pages/overview';
 import { SetupPage } from './pages/setup';
@@ -13,21 +14,24 @@ export class OpportunitySplits extends BrowserforcePlugin {
     const response = {
       enabled: await overviewPage.isEnabled()
     };
+    await page.close();
     return response;
   }
 
   public async apply(config: Config): Promise<void> {
+    let page: Page;
     if (config.enabled) {
-      const page = await this.browserforce.openPage(SetupPage.PATH);
+      page = await this.browserforce.openPage(SetupPage.PATH);
       const setupPage = new SetupPage(page);
       const layoutSelectionPage = await setupPage.enable();
       const overviewPage = await layoutSelectionPage.choose();
       await overviewPage.waitUntilEnabled();
     } else {
-      const page = await this.browserforce.openPage(OverviewPage.PATH);
+      page = await this.browserforce.openPage(OverviewPage.PATH);
       const overviewPage = new OverviewPage(page);
       await overviewPage.disable();
       await overviewPage.waitUntilDisabled();
     }
+    await page.close();
   }
 }

--- a/src/plugins/picklists/field-dependencies/pages.ts
+++ b/src/plugins/picklists/field-dependencies/pages.ts
@@ -33,7 +33,7 @@ export class FieldDependencyPage {
       });
       await Promise.all([
         this.page.waitForNavigation(),
-        actionLinkHandles[0].click()
+        this.page.evaluate((e) => e.click(), actionLinkHandles[0])
       ]);
       await throwPageErrors(this.page);
     }

--- a/src/plugins/picklists/field-dependencies/pages.ts
+++ b/src/plugins/picklists/field-dependencies/pages.ts
@@ -83,5 +83,6 @@ export class NewFieldDependencyPage {
       this.page.click(this.saveButton)
     ]);
     await throwPageErrors(this.page);
+    await this.page.close();
   }
 }

--- a/src/plugins/picklists/index.e2e-spec.ts
+++ b/src/plugins/picklists/index.e2e-spec.ts
@@ -4,9 +4,22 @@ import * as path from 'path';
 import { Picklists } from '.';
 import { FieldDependencies } from './field-dependencies';
 
-describe(Picklists.name, function() {
-  this.slow('30s');
+describe(Picklists.name, function () {
   this.timeout('10m');
+  let plugin;
+  before(() => {
+    plugin = new Picklists(global.bf);
+  });
+
+  const configNew = require('./new.json').settings.picklists;
+  const configReplace = require('./replace.json').settings.picklists;
+  const configReplaceAndDelete = require('./replace-and-delete.json').settings
+    .picklists;
+  const configDeactivate = require('./deactivate.json').settings.picklists;
+  const configActivate = require('./activate.json').settings.picklists;
+  const configReplaceAndDeactivate = require('./replace-and-deactivate.json')
+    .settings.picklists;
+
   it('should deploy a CustomObject for testing', () => {
     const sourceDeployCmd = child.spawnSync('sfdx', [
       'force:source:deploy',
@@ -20,189 +33,70 @@ describe(Picklists.name, function() {
       sourceDeployCmd.output.toString()
     );
   });
-  it('should add a new picklist value when it does not exist', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'new.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'picklistValues' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should add a new picklist value when it does not exist', async () => {
+    await plugin.run(configNew);
   });
-  it('should not do anything when picklist value already exists', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'new.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should not do anything when picklist value already exists', async () => {
+    const res = await plugin.run(configNew);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should replace picklist values', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'replace.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /changing 'picklistValues' to.*/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should replace picklist values', async () => {
+    await plugin.run(configReplace);
   });
-  it('should replace and delete picklist values', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'replace-and-delete.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /changing 'picklistValues' to.*/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should replace and delete picklist values', async () => {
+    await plugin.run(configReplaceAndDelete);
   });
-  it('should not do anything when the picklist values do not exist', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'replace-and-delete.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should not do anything when the picklist values do not exist', async () => {
+    const res = await plugin.run(configReplaceAndDelete);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should deactivate picklist value', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'deactivate.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'picklistValues' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should deactivate picklist value', async () => {
+    await plugin.run(configDeactivate);
   });
-  it('should activate picklist value', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'activate.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'picklistValues' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should activate picklist value', async () => {
+    await plugin.run(configActivate);
   });
-  it('should not do anything when the picklist values do not exist', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'activate.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should not do anything when the picklist values already exist', async () => {
+    const res = await plugin.run(configActivate);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should replace and deactivate a picklist value', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'replace-and-deactivate.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /changing 'picklistValues' to.*/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should replace and deactivate a picklist value', async () => {
+    await plugin.run(configReplaceAndDeactivate);
   });
 });
 
-describe(FieldDependencies.name, function() {
-  this.slow('30s');
+describe(FieldDependencies.name, function () {
   this.timeout('10m');
-  it('should not do anything when the dependency is already set', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'field-dependencies', 'set.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  let plugin;
+  before(() => {
+    plugin = new FieldDependencies(global.bf);
   });
-  it('should unset a field dependency', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'field-dependencies', 'unset.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+
+  const configSet = require('./field-dependencies/set.json').settings.picklists
+    .fieldDependencies;
+  const configUnset = require('./field-dependencies/unset.json').settings
+    .picklists.fieldDependencies;
+  const configChange = require('./field-dependencies/change.json').settings
+    .picklists.fieldDependencies;
+
+  it('should not do anything when the dependency is already set', async () => {
+    const res = await plugin.run(configSet);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should not do anything when the dependency is already unset', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'field-dependencies', 'unset.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should unset a field dependency', async () => {
+    await plugin.run(configUnset);
   });
-  it('should set a field dependency', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'field-dependencies', 'set.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should not do anything when the dependency is already unset', async () => {
+    const res = await plugin.run(configUnset);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should change a field dependency', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'field-dependencies', 'change.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should set a field dependency', async () => {
+    await plugin.run(configSet);
   });
-  it('should change back a field dependency', () => {
-    const cmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'field-dependencies', 'set.json'))
-    ]);
-    assert.deepStrictEqual(cmd.status, 0, cmd.output.toString());
-    assert.ok(
-      /changing 'fieldDependencies' to.*/.test(cmd.output.toString()),
-      cmd.output.toString()
-    );
+  it('should change a field dependency', async () => {
+    await plugin.run(configChange);
+  });
+  it('should change back a field dependency', async () => {
+    await plugin.run(configSet);
   });
 });

--- a/src/plugins/picklists/index.ts
+++ b/src/plugins/picklists/index.ts
@@ -68,8 +68,7 @@ export class Picklists extends BrowserforcePlugin {
     }
     if (definition.fieldDependencies) {
       result.fieldDependencies = await new FieldDependencies(
-        this.browserforce,
-        this.org
+        this.browserforce
       ).retrieve(definition.fieldDependencies);
     }
     return result;
@@ -104,8 +103,7 @@ export class Picklists extends BrowserforcePlugin {
     }
     if (definition.fieldDependencies) {
       changes['fieldDependencies'] = new FieldDependencies(
-        this.browserforce,
-        this.org
+        this.browserforce
       ).diff(state.fieldDependencies, definition.fieldDependencies);
     }
     return removeEmptyValues(changes);
@@ -163,7 +161,7 @@ export class Picklists extends BrowserforcePlugin {
       }
     }
     if (config.fieldDependencies) {
-      await new FieldDependencies(this.browserforce, this.org).apply(
+      await new FieldDependencies(this.browserforce).apply(
         config.fieldDependencies
       );
     }

--- a/src/plugins/picklists/index.ts
+++ b/src/plugins/picklists/index.ts
@@ -63,6 +63,7 @@ export class Picklists extends BrowserforcePlugin {
         state._newValueExists =
           Boolean(newValueMatch) || action.newValue === null;
         result.picklistValues.push(state);
+        await page.close();
       }
     }
     if (definition.fieldDependencies) {
@@ -158,6 +159,7 @@ export class Picklists extends BrowserforcePlugin {
             action.replaceAllBlankValues
           );
         }
+        await page.close();
       }
     }
     if (config.fieldDependencies) {

--- a/src/plugins/picklists/pages.ts
+++ b/src/plugins/picklists/pages.ts
@@ -51,10 +51,10 @@ export class PicklistPage {
     const NEW_ACTION_BUTTON_XPATH =
       '//tr[td[2]]//input[contains(@onclick, "/setup/ui/picklist_masteredit")][@value=" New "]';
     await this.page.waitForXPath(NEW_ACTION_BUTTON_XPATH);
-    const NEW_ACTION_BUTTON = (await this.page.$x(NEW_ACTION_BUTTON_XPATH))[0];
+    const newActionButton = (await this.page.$x(NEW_ACTION_BUTTON_XPATH))[0];
     await Promise.all([
       this.page.waitForNavigation(),
-      NEW_ACTION_BUTTON.click()
+      this.page.evaluate((e) => e.click(), newActionButton)
     ]);
   }
 
@@ -73,18 +73,13 @@ export class PicklistPage {
   ): Promise<PicklistReplaceAndDeletePage> {
     const xpath = `//tr[td[2][text() = "${picklistValueApiName}"]]//td[1]//a[contains(@href, "/setup/ui/picklist_masterdelete.jsp") and contains(@href, "deleteType=0")]`;
     await this.page.waitForXPath(xpath);
-    const actionLinkHandles = await this.page.$x(xpath);
-    if (actionLinkHandles.length !== 1) {
-      throw new Error(
-        `Could not find delete action for picklist value: ${picklistValueApiName}`
-      );
-    }
-    this.page.on('dialog', async dialog => {
+    const deleteLink = (await this.page.$x(xpath))[0];
+    this.page.on('dialog', async (dialog) => {
       await dialog.accept();
     });
     await Promise.all([
       this.page.waitForNavigation(),
-      actionLinkHandles[0].click()
+      this.page.evaluate((e) => e.click(), deleteLink)
     ]);
     await throwPageErrors(this.page);
     return new PicklistReplaceAndDeletePage(this.page);
@@ -95,27 +90,19 @@ export class PicklistPage {
     active: boolean
   ): Promise<PicklistPage> {
     let xpath;
-    let actionName;
     if (active) {
       xpath = `//tr[td[2][text() = "${picklistValueApiName}"]]//td[1]//a[contains(@href, "/setup/ui/picklist_masteractivate.jsp")]`;
-      actionName = 'activate';
     } else {
       xpath = `//tr[td[2][text() = "${picklistValueApiName}"]]//td[1]//a[contains(@href, "/setup/ui/picklist_masterdelete.jsp") and contains(@href, "deleteType=1")]`;
-      actionName = 'deactivate';
     }
     await this.page.waitForXPath(xpath);
-    const actionLinkHandles = await this.page.$x(xpath);
-    if (actionLinkHandles.length !== 1) {
-      throw new Error(
-        `Could not find ${actionName} action for picklist value: ${picklistValueApiName}`
-      );
-    }
-    this.page.on('dialog', async dialog => {
+    const actionLink = (await this.page.$x(xpath))[0];
+    this.page.on('dialog', async (dialog) => {
       await dialog.accept();
     });
     await Promise.all([
       this.page.waitForNavigation(),
-      actionLinkHandles[0].click()
+      this.page.evaluate((e) => e.click(), actionLink)
     ]);
     await throwPageErrors(this.page);
     return this.page;

--- a/src/plugins/record-types/index.e2e-spec.ts
+++ b/src/plugins/record-types/index.e2e-spec.ts
@@ -3,11 +3,36 @@ import * as child from 'child_process';
 import * as path from 'path';
 import { RecordTypes } from '.';
 
-describe(RecordTypes.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  this.slow('30s');
+describe(RecordTypes.name, function () {
   this.timeout('10m');
+  let plugin;
+  before(() => {
+    plugin = new RecordTypes(global.bf);
+  });
+
+  const configDelete = {
+    deletions: [
+      {
+        fullName: 'Vehicle__c.SUV'
+      }
+    ]
+  };
+  const configDeleteActive = {
+    deletions: [
+      {
+        fullName: 'Vehicle__c.CUV'
+      }
+    ]
+  };
+  const configDeleteAndReplace = {
+    deletions: [
+      {
+        fullName: 'Vehicle__c.SportsCar',
+        replacement: 'Vehicle__c.Bicycle'
+      }
+    ]
+  };
+
   it('should deploy a CustomObject for testing', () => {
     const sourceDeployCmd = child.spawnSync('sfdx', [
       'force:source:deploy',
@@ -21,52 +46,29 @@ describe(RecordTypes.name, function() {
       sourceDeployCmd.output.toString()
     );
   });
-  it('should delete a record type', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'delete.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /changing 'deletions' to.*/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should delete a record type', async () => {
+    await plugin.run(configDelete);
   });
-  it('should not do anything when the record type does not exist', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'delete.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should not do anything when the record type does not exist', async () => {
+    const res = await plugin.run(configDelete);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should fail deleting an active record type', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'delete-active.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 1, replaceCmd.output.toString());
-    assert.ok(
-      /Cannot delete active RecordType/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should fail deleting an active record type', async () => {
+    let err;
+    try {
+      await plugin.run(configDeleteActive);
+    } catch (e) {
+      err = e;
+    }
+    assert.throws(() => {
+      throw err;
+    }, /Cannot delete active RecordType/);
   });
-  it('should delete and replace a record type', () => {
-    const replaceCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'delete-and-replace.json'))
-    ]);
-    assert.deepStrictEqual(replaceCmd.status, 0, replaceCmd.output.toString());
-    assert.ok(
-      /changing 'deletions' to.*/.test(replaceCmd.output.toString()),
-      replaceCmd.output.toString()
-    );
+  it('should delete and replace a record type', async () => {
+    await plugin.run(configDeleteAndReplace);
+  });
+  it('should not need to do anything for non-existent picklists', async () => {
+    const res = await plugin.run(configDeleteAndReplace);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
 });

--- a/src/plugins/record-types/index.ts
+++ b/src/plugins/record-types/index.ts
@@ -80,6 +80,7 @@ export class RecordTypes extends BrowserforcePlugin {
         newRecordTypeId = replacementRecordType.Id;
       }
       await deletePage.replace(newRecordTypeId);
+      await page.close();
     }
   }
 }

--- a/src/plugins/record-types/index.ts
+++ b/src/plugins/record-types/index.ts
@@ -86,9 +86,10 @@ export class RecordTypes extends BrowserforcePlugin {
 }
 
 async function listRecordTypes(conn) {
-  return await conn.metadata.list({
+  const recordTypes = await conn.metadata.list({
     type: 'RecordType'
   });
+  return recordTypes;
 }
 
 type RecordType = {

--- a/src/plugins/record-types/pages.ts
+++ b/src/plugins/record-types/pages.ts
@@ -15,15 +15,10 @@ export class RecordTypePage {
       15
     )}")]`;
     await this.page.waitForXPath(xpath);
-    const actionLinkHandles = await this.page.$x(xpath);
-    if (actionLinkHandles.length !== 1) {
-      throw new Error(
-        `Could not find delete action for record type id: ${recordTypeId}`
-      );
-    }
+    const deleteLink = (await this.page.$x(xpath))[0];
     await Promise.all([
       this.page.waitForNavigation(),
-      actionLinkHandles[0].click()
+      this.page.evaluate((e) => e.click(), deleteLink)
     ]);
     return new RecordTypeDeletePage(this.page);
   }

--- a/src/plugins/relate-contact-to-multiple-accounts/index.e2e-spec.ts
+++ b/src/plugins/relate-contact-to-multiple-accounts/index.e2e-spec.ts
@@ -1,57 +1,31 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { RelateContactToMultipleAccounts } from '.';
 
-describe(RelateContactToMultipleAccounts.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+describe(RelateContactToMultipleAccounts.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new RelateContactToMultipleAccounts(global.bf);
   });
-  it('should already be enabled', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'enable.json')
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+
+  const configEnabled = {
+    enabled: true
+  };
+  const configDisabled = {
+    enabled: false
+  };
+
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
   });
-  it('should disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should be enabled', async () => {
+    const res = await plugin.run(configEnabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
-  it('should already be disabled', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.join(__dirname, 'disable.json')
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /no action necessary/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+  it('should disable', async () => {
+    await plugin.run(configDisabled);
+  });
+  it('should be disabled', async () => {
+    const res = await plugin.run(configDisabled);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
   });
 });

--- a/src/plugins/relate-contact-to-multiple-accounts/index.ts
+++ b/src/plugins/relate-contact-to-multiple-accounts/index.ts
@@ -23,6 +23,7 @@ export class RelateContactToMultipleAccounts extends BrowserforcePlugin {
         (el: HTMLInputElement) => el.checked
       )
     };
+    await page.close();
     return response;
   }
 
@@ -49,5 +50,6 @@ export class RelateContactToMultipleAccounts extends BrowserforcePlugin {
       page.waitForNavigation(),
       page.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/relate-contact-to-multiple-accounts/index.ts
+++ b/src/plugins/relate-contact-to-multiple-accounts/index.ts
@@ -16,6 +16,12 @@ type Config = {
 export class RelateContactToMultipleAccounts extends BrowserforcePlugin {
   public async retrieve(definition?: Config): Promise<Config> {
     const page = await this.browserforce.openPage(PATHS.BASE);
+    // First we have to click the 'Edit' button, to see the checkbox
+    await page.waitForSelector(SELECTORS.EDIT_BUTTON);
+    await Promise.all([
+      page.waitForNavigation(),
+      page.click(SELECTORS.EDIT_BUTTON)
+    ]);
     await page.waitForSelector(SELECTORS.ENABLED);
     const response = {
       enabled: await page.$eval(

--- a/src/plugins/reports-and-dashboards/folder-sharing/index.ts
+++ b/src/plugins/reports-and-dashboards/folder-sharing/index.ts
@@ -1,3 +1,4 @@
+import { Page } from 'puppeteer';
 import { BrowserforcePlugin } from '../../../plugin';
 
 const PATHS = {
@@ -18,8 +19,9 @@ export class FolderSharing extends BrowserforcePlugin {
     const response = {
       enableEnhancedFolderSharing: true
     };
+    let page: Page;
     try {
-      const page = await this.browserforce.openPage(PATHS.BASE);
+      page = await this.browserforce.openPage(PATHS.BASE);
       const frameOrPage = await this.browserforce.waitForSelectorInFrameOrPage(
         page,
         SELECTORS.BASE
@@ -40,6 +42,7 @@ export class FolderSharing extends BrowserforcePlugin {
       }
       throw e;
     }
+    await page.close();
     return response;
   }
 
@@ -63,5 +66,6 @@ export class FolderSharing extends BrowserforcePlugin {
       page.waitForNavigation(),
       page.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/reports-and-dashboards/index.ts
+++ b/src/plugins/reports-and-dashboards/index.ts
@@ -11,10 +11,7 @@ export class ReportsAndDashboards extends BrowserforcePlugin {
     const response: Config = {};
     if (definition) {
       if (definition.folderSharing) {
-        const pluginFolderSharing = new FolderSharing(
-          this.browserforce,
-          this.org
-        );
+        const pluginFolderSharing = new FolderSharing(this.browserforce);
         response.folderSharing = await pluginFolderSharing.retrieve(
           definition.folderSharing
         );
@@ -24,7 +21,7 @@ export class ReportsAndDashboards extends BrowserforcePlugin {
   }
 
   public diff(state: Config, definition: Config): Config {
-    const pluginFolderSharing = new FolderSharing(null, null);
+    const pluginFolderSharing = new FolderSharing(null);
     const response = {
       folderSharing: pluginFolderSharing.diff(
         state.folderSharing,
@@ -36,10 +33,7 @@ export class ReportsAndDashboards extends BrowserforcePlugin {
 
   public async apply(plan: Config): Promise<void> {
     if (plan.folderSharing) {
-      const pluginFolderSharing = new FolderSharing(
-        this.browserforce,
-        this.org
-      );
+      const pluginFolderSharing = new FolderSharing(this.browserforce);
       await pluginFolderSharing.apply(plan.folderSharing);
     }
   }

--- a/src/plugins/salesforce-to-salesforce/index.e2e-spec.ts
+++ b/src/plugins/salesforce-to-salesforce/index.e2e-spec.ts
@@ -1,37 +1,35 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { SalesforceToSalesforce } from '.';
 
-describe(SalesforceToSalesforce.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to 'true'/.test(enableCmd.output.toString()),
-      enableCmd.output.toString()
-    );
+describe(SalesforceToSalesforce.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new SalesforceToSalesforce(global.bf);
   });
-  it('should fail to disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 1, disableCmd.output.toString());
-    assert.ok(
-      /to 'false'/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
-    assert.ok(
-      /cannot be disabled/.test(disableCmd.output.toString()),
-      disableCmd.output.toString()
-    );
+
+  const configEnabled = {
+    enabled: true
+  };
+  const configDisabled = {
+    enabled: false
+  };
+
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
+  });
+  it('should be enabled', async () => {
+    const state = await plugin.retrieve();
+    assert.deepStrictEqual(state, configEnabled);
+  });
+  it('should fail to disable', async () => {
+    let err;
+    try {
+      await plugin.apply(configDisabled);
+    } catch (e) {
+      err = e;
+    }
+    assert.throws(() => {
+      throw err;
+    }, /cannot be disabled/);
   });
 });

--- a/src/plugins/salesforce-to-salesforce/index.ts
+++ b/src/plugins/salesforce-to-salesforce/index.ts
@@ -28,6 +28,7 @@ export class SalesforceToSalesforce extends BrowserforcePlugin {
         (el: HTMLInputElement) => el.checked
       );
     }
+    await page.close();
     return response;
   }
 
@@ -51,6 +52,7 @@ export class SalesforceToSalesforce extends BrowserforcePlugin {
         page.click(SELECTORS.SAVE_BUTTON)
       ]);
       const result = await this.retrieve();
+      await page.close();
       if (result.enabled !== config.enabled) {
         throw new Error('setting was not applied as expected');
       }

--- a/src/plugins/security/certificate-and-key-management/index.ts
+++ b/src/plugins/security/certificate-and-key-management/index.ts
@@ -155,6 +155,7 @@ export class CertificateAndKeyManagement extends BrowserforcePlugin {
             page.waitForNavigation(),
             page.click(SELECTORS.SAVE_BUTTON)
           ]);
+          await page.close();
         }
       }
     }
@@ -197,7 +198,9 @@ export class CertificateAndKeyManagement extends BrowserforcePlugin {
             certPage.waitForNavigation(),
             certPage.click(SELECTORS.SAVE_BUTTON)
           ]);
+          await certPage.close();
         }
+        await page.close();
       }
     }
   }

--- a/src/plugins/security/identity-provider/index.ts
+++ b/src/plugins/security/identity-provider/index.ts
@@ -40,6 +40,7 @@ export class IdentityProvider extends BrowserforcePlugin {
         certNameHandle
       );
     }
+    await page.close();
     return response;
   }
 
@@ -97,6 +98,7 @@ export class IdentityProvider extends BrowserforcePlugin {
             page.waitForNavigation(),
             page.click(SELECTORS.SAVE_BUTTON)
           ]);
+          await page.close();
         },
         {
           retries: 5,
@@ -114,6 +116,7 @@ export class IdentityProvider extends BrowserforcePlugin {
         page.waitForNavigation(),
         page.click(SELECTORS.DISABLE_BUTTON)
       ]);
+      await page.close();
     }
   }
 }

--- a/src/plugins/security/index.ts
+++ b/src/plugins/security/index.ts
@@ -26,34 +26,27 @@ export class Security extends BrowserforcePlugin {
     const response: Config = {};
     if (definition) {
       if (definition.certificateAndKeyManagement) {
-        const pluginCKM = new CertificateAndKeyManagement(
-          this.browserforce,
-          this.org
-        );
+        const pluginCKM = new CertificateAndKeyManagement(this.browserforce);
         response.certificateAndKeyManagement = await pluginCKM.retrieve(
           definition.certificateAndKeyManagement
         );
       }
       if (definition.identityProvider) {
-        const pluginIdentityProvider = new IdentityProvider(
-          this.browserforce,
-          this.org
-        );
+        const pluginIdentityProvider = new IdentityProvider(this.browserforce);
         response.identityProvider = await pluginIdentityProvider.retrieve(
           definition.identityProvider
         );
       }
       if (definition.loginAccessPolicies) {
         const pluginLoginAccessPolicies = new LoginAccessPolicies(
-          this.browserforce,
-          this.org
+          this.browserforce
         );
         response.loginAccessPolicies = await pluginLoginAccessPolicies.retrieve(
           definition.loginAccessPolicies
         );
       }
       if (definition.sharing) {
-        const pluginSharing = new Sharing(this.browserforce, this.org);
+        const pluginSharing = new Sharing(this.browserforce);
         response.sharing = await pluginSharing.retrieve(definition.sharing);
       }
     }
@@ -61,10 +54,10 @@ export class Security extends BrowserforcePlugin {
   }
 
   public diff(state: Config, definition: Config): Config {
-    const pluginCKM = new CertificateAndKeyManagement(null, null);
-    const pluginIdentityProvider = new IdentityProvider(null, null);
-    const pluginLoginAccessPolicies = new LoginAccessPolicies(null, null);
-    const pluginSharing = new Sharing(null, null);
+    const pluginCKM = new CertificateAndKeyManagement(null);
+    const pluginIdentityProvider = new IdentityProvider(null);
+    const pluginLoginAccessPolicies = new LoginAccessPolicies(null);
+    const pluginSharing = new Sharing(null);
     const response = {
       certificateAndKeyManagement: pluginCKM.diff(
         state.certificateAndKeyManagement,
@@ -85,28 +78,21 @@ export class Security extends BrowserforcePlugin {
 
   public async apply(plan: Config): Promise<void> {
     if (plan.certificateAndKeyManagement) {
-      const pluginCKM = new CertificateAndKeyManagement(
-        this.browserforce,
-        this.org
-      );
+      const pluginCKM = new CertificateAndKeyManagement(this.browserforce);
       await pluginCKM.apply(plan.certificateAndKeyManagement);
     }
     if (plan.identityProvider) {
-      const pluginIdentityProvider = new IdentityProvider(
-        this.browserforce,
-        this.org
-      );
+      const pluginIdentityProvider = new IdentityProvider(this.browserforce);
       await pluginIdentityProvider.apply(plan.identityProvider);
     }
     if (plan.loginAccessPolicies) {
       const pluginLoginAccessPolicies = new LoginAccessPolicies(
-        this.browserforce,
-        this.org
+        this.browserforce
       );
       await pluginLoginAccessPolicies.apply(plan.loginAccessPolicies);
     }
     if (plan.sharing) {
-      const pluginSharing = new Sharing(this.browserforce, this.org);
+      const pluginSharing = new Sharing(this.browserforce);
       await pluginSharing.apply(plan.sharing);
     }
   }

--- a/src/plugins/security/login-access-policies/index.e2e-spec.ts
+++ b/src/plugins/security/login-access-policies/index.e2e-spec.ts
@@ -1,37 +1,29 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
-import { LoginAccessPolicies } from '.';
+import { type Config, LoginAccessPolicies } from '.';
 
-describe(LoginAccessPolicies.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /changing 'loginAccessPolicies' to '{"administratorsCanLogInAsAnyUser":true}'/.test(
-        enableCmd.output.toString()
-      ),
-      enableCmd.output.toString()
-    );
+describe(LoginAccessPolicies.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new LoginAccessPolicies(global.bf);
   });
-  it('should disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /changing 'loginAccessPolicies' to '{"administratorsCanLogInAsAnyUser":false}'/.test(
-        disableCmd.output.toString()
-      ),
-      disableCmd.output.toString()
-    );
+
+  describe('administratorsCanLogInAsAnyUser', () => {
+    const configDisabled: Config = { administratorsCanLogInAsAnyUser: false };
+    const configEnabled: Config = { administratorsCanLogInAsAnyUser: true };
+
+    it('should enable', async () => {
+      await plugin.run(configEnabled);
+    });
+    it('should be enabled', async () => {
+      const res = await plugin.retrieve();
+      assert.deepStrictEqual(res, configEnabled);
+    });
+    it('should disable', async () => {
+      await plugin.apply(configDisabled);
+    });
+    it('should be disabled', async () => {
+      const res = await plugin.retrieve();
+      assert.deepStrictEqual(res, configDisabled);
+    });
   });
 });

--- a/src/plugins/security/login-access-policies/index.ts
+++ b/src/plugins/security/login-access-policies/index.ts
@@ -23,6 +23,7 @@ export class LoginAccessPolicies extends BrowserforcePlugin {
         (el: HTMLInputElement) => el.checked
       )
     };
+    await page.close();
     return response;
   }
 
@@ -40,5 +41,6 @@ export class LoginAccessPolicies extends BrowserforcePlugin {
       page.waitForSelector(SELECTORS.CONFIRM_MESSAGE),
       page.click(SELECTORS.SAVE_BUTTON)
     ]);
+    await page.close();
   }
 }

--- a/src/plugins/security/sharing/index.e2e-spec.ts
+++ b/src/plugins/security/sharing/index.e2e-spec.ts
@@ -1,37 +1,31 @@
 import assert from 'assert';
-import * as child from 'child_process';
-import * as path from 'path';
 import { Sharing } from '.';
 
-describe.skip(Sharing.name, function() {
-  this.slow('30s');
-  this.timeout('2m');
-  it('should enable', () => {
-    const enableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'enable.json'))
-    ]);
-    assert.deepStrictEqual(enableCmd.status, 0, enableCmd.output.toString());
-    assert.ok(
-      /to '{"enableExternalSharingModel":true}'/.test(
-        enableCmd.output.toString()
-      ),
-      enableCmd.output.toString()
-    );
+describe.skip(Sharing.name, function () {
+  let plugin;
+  before(() => {
+    plugin = new Sharing(global.bf);
   });
-  it('should disable', () => {
-    const disableCmd = child.spawnSync(path.resolve('bin', 'run'), [
-      'browserforce:apply',
-      '-f',
-      path.resolve(path.join(__dirname, 'disable.json'))
-    ]);
-    assert.deepStrictEqual(disableCmd.status, 0, disableCmd.output.toString());
-    assert.ok(
-      /to '{"enableExternalSharingModel":false}'/.test(
-        disableCmd.output.toString()
-      ),
-      disableCmd.output.toString()
-    );
+
+  const configEnabled = {
+    enableExternalSharingModel: true
+  };
+  const configDisabled = {
+    enableExternalSharingModel: true
+  };
+
+  it('should enable', async () => {
+    await plugin.run(configEnabled);
+  });
+  it('should be enabled', async () => {
+    const state = await plugin.retrieve();
+    assert.deepStrictEqual(state, configEnabled);
+  });
+  it('should disable', async () => {
+    await plugin.apply(configDisabled);
+  });
+  it('should be disabled', async () => {
+    const state = await plugin.retrieve();
+    assert.deepStrictEqual(state, configDisabled);
   });
 });

--- a/src/plugins/security/sharing/index.ts
+++ b/src/plugins/security/sharing/index.ts
@@ -23,6 +23,7 @@ export class Sharing extends BrowserforcePlugin {
       SELECTORS.EXTERNAL_SHARING_MODEL_BUTTON,
       (el: HTMLInputElement) => el.onclick.toString()
     );
+    await page.close();
     return {
       enableExternalSharingModel:
         buttonOnclick.indexOf(SELECTORS.MODAL_DIALOG) >= 0
@@ -46,5 +47,6 @@ export class Sharing extends BrowserforcePlugin {
         page.click(SELECTORS.DISABLE_BUTTON)
       ]);
     }
+    await page.close();
   }
 }

--- a/src/plugins/utils.ts
+++ b/src/plugins/utils.ts
@@ -40,3 +40,10 @@ export function semanticallyCleanObject(obj: any, id = 'id'): any {
   }
   return obj;
 }
+
+export function isEmpty(obj: unknown): Boolean {
+  return !(
+    (obj !== undefined && obj !== null && obj !== Object(obj)) ||
+    (obj === Object(obj) && Object.keys(obj).length > 0)
+  );
+}

--- a/test/browserforce.e2e-spec.ts
+++ b/test/browserforce.e2e-spec.ts
@@ -34,7 +34,7 @@ describe('Browser', function () {
       const bf = new Browserforce(defaultScratchOrg, ux);
       await bf.login();
       const myDomain = bf.getMyDomain();
-      assert.notDeepEqual(null, myDomain);
+      assert.notDeepStrictEqual(null, myDomain);
       await bf.logout();
     });
   });
@@ -45,7 +45,7 @@ describe('Browser', function () {
       const bf = new Browserforce(defaultScratchOrg, ux);
       await bf.login();
       const instanceDomain = bf.getInstanceDomain();
-      assert.notDeepEqual(null, instanceDomain);
+      assert.notDeepStrictEqual(null, instanceDomain);
       await bf.logout();
     });
   });
@@ -56,7 +56,7 @@ describe('Browser', function () {
       const bf = new Browserforce(defaultScratchOrg, ux);
       await bf.login();
       const lexUrl = bf.getLightningUrl();
-      assert.notDeepEqual(null, lexUrl);
+      assert.notDeepStrictEqual(null, lexUrl);
       await bf.logout();
     });
   });

--- a/test/browserforce.e2e-spec.ts
+++ b/test/browserforce.e2e-spec.ts
@@ -4,8 +4,6 @@ import assert from 'assert';
 import { Browserforce } from '../src/browserforce';
 
 describe('Browser', function () {
-  this.slow('30s');
-  this.timeout('2m');
   describe('login()', () => {
     it('should successfully login with valid credentials', async () => {
       const defaultScratchOrg = await Org.create({});

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -1,0 +1,15 @@
+import { Org } from '@salesforce/core';
+import { Browserforce } from '../src/browserforce';
+import { UX } from '@salesforce/command';
+
+before('global setup', async () => {
+  const org = await Org.create({});
+  const ux = await UX.create();
+  const bf = new Browserforce(org, ux);
+  global.bf = bf;
+  await bf.login();
+});
+
+after('global setup', async () => {
+  await global.bf.logout();
+});

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -13,12 +13,12 @@ class DummyPlugin extends BrowserforcePlugin {
 describe('BrowserforcePlugin', () => {
   describe('#diff()', async () => {
     it('generates a diff for a simple object', async () => {
-      const plugin = new DummyPlugin(null, null);
+      const plugin = new DummyPlugin(null);
       const actions = plugin.diff({ a: 1 }, { a: 2 });
       assert.deepStrictEqual(actions, { a: 2 });
     });
     it('generates a diff for a deep object', async () => {
-      const plugin = new DummyPlugin(null, null);
+      const plugin = new DummyPlugin(null);
       const actions = plugin.diff(
         {
           a: [
@@ -32,7 +32,7 @@ describe('BrowserforcePlugin', () => {
       assert.deepStrictEqual(actions, { a: [{ a: 2 }] });
     });
     it('generates a diff for a deep object', async () => {
-      const plugin = new DummyPlugin(null, null);
+      const plugin = new DummyPlugin(null);
       const actions = plugin.diff(
         {
           a: [
@@ -56,7 +56,7 @@ describe('BrowserforcePlugin', () => {
       assert.deepStrictEqual(actions, { a: [{ a: 2, b: true }] });
     });
     it('generates a diff for an array', async () => {
-      const plugin = new DummyPlugin(null, null);
+      const plugin = new DummyPlugin(null);
       const actions = plugin.diff(
         [
           {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { semanticallyCleanObject } from '../src/plugins/utils';
+import { isEmpty, semanticallyCleanObject } from '../src/plugins/utils';
 
 describe('semanticallyCleanObject', () => {
   it('should clean object', async () => {
@@ -22,5 +22,32 @@ describe('semanticallyCleanObject', () => {
       semanticallyCleanObject({ myid: 'a2', a: 'hi' }, 'myid'),
       { myid: 'a2', a: 'hi' }
     );
+  });
+});
+
+describe('isEmpty', () => {
+  it('boolean should not be empty', async () => {
+    assert.deepStrictEqual(isEmpty(false), false);
+  });
+  it('string should not be empty', async () => {
+    assert.deepStrictEqual(isEmpty('foo'), false);
+  });
+  it('string should not be empty', async () => {
+    assert.deepStrictEqual(isEmpty('foo'), false);
+  });
+  it('non-empty object should not be empty', async () => {
+    assert.deepStrictEqual(isEmpty({ foo: 'bar' }), false);
+  });
+  it('non-empty array should not be empty', async () => {
+    assert.deepStrictEqual(isEmpty(['bar']), false);
+  });
+  it('empty string should be empty', async () => {
+    assert.deepStrictEqual(isEmpty(''), false);
+  });
+  it('empty object should be empty', async () => {
+    assert.deepStrictEqual(isEmpty({}), true);
+  });
+  it('empty array should be empty', async () => {
+    assert.deepStrictEqual(isEmpty([]), true);
   });
 });


### PR DESCRIPTION
- don't run plugin by spawning child processes anymore
- provide `global.bf` browserforce instance with already logged in page
- import and run plugin code
- add convenience `myplugin.run(config)` method which runs `retrieve/diff/apply`
- use only one browser instance for the whole test run