### PR TITLE
chore: refactor org login from environment variable

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           SFDX_AUTH_URL_DEVHUB: ${{ secrets.SFDX_AUTH_URL_DEVHUB }}
         run: |
-          sf org login sfdx-url -d -a devhub -f /dev/stdin <<< "${SFDX_AUTH_URL_DEVHUB}"
+          sf org login sfdx-url -d -a devhub -f <(echo "${SFDX_AUTH_URL_DEVHUB}")
           yarn develop
       - name: Run end-to-end tests
         run: yarn test:e2e

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           SFDX_AUTH_URL_DEVHUB: ${{ secrets.SFDX_AUTH_URL_DEVHUB }}
         run: |
-          sf org login sfdx-url -d -a devhub -f /dev/stdin <<< "${SFDX_AUTH_URL_DEVHUB}"
+          sf org login sfdx-url -d -a devhub -f <(echo "${SFDX_AUTH_URL_DEVHUB}")
           yarn develop --release preview
       - name: Run end-to-end tests
         run: yarn test:e2e


### PR DESCRIPTION

Use bash process substitution which makes the input appear as a filename instead of /dev/stdin.
