### PR TITLE
feat: enable auth services in Authentication Configuration (My Domain)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Create a scratch org and try it yourself:
 
 ```console
 sf org create scratch -f config/project-scratch-def.json -a browserforce-dev -d
-BROWSER_DEBUG=true ./bin/run browserforce apply -f src/plugins/admins-can-log-in-as-any-user/enable.json -u browserforce-dev
-BROWSER_DEBUG=true ./bin/run browserforce apply -f src/plugins/admins-can-log-in-as-any-user/disable.json -u browserforce-dev
+BROWSER_DEBUG=true ./bin/run browserforce apply -f src/plugins/admins-can-log-in-as-any-user/enable.json -o browserforce-dev
+BROWSER_DEBUG=true ./bin/run browserforce apply -f src/plugins/admins-can-log-in-as-any-user/disable.json -o browserforce-dev
 ```
 
 Now it's your turn!

--- a/src/plugins/security/authentication-configuration/disable.json
+++ b/src/plugins/security/authentication-configuration/disable.json
@@ -5,7 +5,7 @@
       "authenticationConfiguration": {
         "services": [
           {
-            "label" : "Quip",
+            "label" : "Login Form",
             "enabled": false
           }
         ]

--- a/src/plugins/security/authentication-configuration/disable.json
+++ b/src/plugins/security/authentication-configuration/disable.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "../../schema.json",
+  "settings": {
+    "security": {
+      "authenticationConfiguration": {
+        "services": [
+          {
+            "label" : "Quip",
+            "enabled": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/plugins/security/authentication-configuration/enable.json
+++ b/src/plugins/security/authentication-configuration/enable.json
@@ -5,11 +5,11 @@
       "authenticationConfiguration": {
         "services": [
           {
-            "label" : "Login Form",
+            "label" : "TestAuthMethod",
             "enabled": true
           },
           {
-            "label" : "Quip",
+            "label" : "Login Form",
             "enabled": true
           }
         ]

--- a/src/plugins/security/authentication-configuration/enable.json
+++ b/src/plugins/security/authentication-configuration/enable.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schema.json",
+  "settings": {
+    "security": {
+      "authenticationConfiguration": {
+        "services": [
+          {
+            "label" : "Login Form",
+            "enabled": true
+          },
+          {
+            "label" : "Quip",
+            "enabled": true
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/plugins/security/authentication-configuration/index.e2e-spec.ts
+++ b/src/plugins/security/authentication-configuration/index.e2e-spec.ts
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import { type Config, AuthenticationConfiguration } from './index.js';
+
+describe(AuthenticationConfiguration.name, function () {
+  let plugin: AuthenticationConfiguration;
+
+  before(() => {
+    plugin = new AuthenticationConfiguration(global.bf);
+  });
+
+  describe('services configuration', () => {
+    const configSingle: Config = {
+      services: [
+        { label: 'Login Form', enabled: true }
+      ]
+    };
+
+    it('should retrieve the single enabled service', async () => {
+      const res = await plugin.retrieve(configSingle);
+      assert.deepStrictEqual(res, configSingle);
+    });
+  });
+});

--- a/src/plugins/security/authentication-configuration/index.e2e-spec.ts
+++ b/src/plugins/security/authentication-configuration/index.e2e-spec.ts
@@ -1,5 +1,11 @@
 import assert from 'assert';
+import * as child from 'child_process';
+import { fileURLToPath } from 'node:url';
+import * as path from 'path';
 import { type Config, AuthenticationConfiguration } from './index.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
 
 describe(AuthenticationConfiguration.name, function () {
   let plugin: AuthenticationConfiguration;
@@ -8,16 +14,79 @@ describe(AuthenticationConfiguration.name, function () {
     plugin = new AuthenticationConfiguration(global.bf);
   });
 
-  describe('services configuration', () => {
-    const configSingle: Config = {
+  describe('authentication configuration', () => {
+    const configRetrieveSingle: Config = {
       services: [
         { label: 'Login Form', enabled: true }
       ]
     };
+    const configRmoveSingle: Config = {
+      services: [
+        { label: 'Login Form', enabled: false }
+      ]
+    };
+    const configApplyMultiple: Config = {
+      services: [
+        { label: 'Login Form', enabled: false },
+        { label: 'TestAuthMethod', enabled: true }
+      ]
+    };
+    const configApplyMissing: Config = {
+      services: [
+        { label: 'FakeAuthMethod', enabled: true }
+      ]
+    };
 
-    it('should retrieve the single enabled service', async () => {
-      const res = await plugin.retrieve(configSingle);
-      assert.deepStrictEqual(res, configSingle);
+    it('should retrieve the single enabled Login Form auth', async () => {
+      const res = await plugin.retrieve(configRetrieveSingle);
+      assert.deepStrictEqual(res, configRetrieveSingle);
+    });
+
+    it('should not do anything when the configuration is already set', async () => {
+      const res = await plugin.run(configRetrieveSingle);
+      assert.deepStrictEqual(res, { message: 'no action necessary' });
+    });
+
+    it('should throw an error when trying to remove the only enabled service', async () => {
+      let err;
+      try {
+        await plugin.apply(configRmoveSingle);
+      } catch (e) {
+        err = e;
+      }
+      assert.throws(() => {
+        throw err;
+      }, /You must select at least one authentication service/);
+    });
+
+    it('should deploy an AuthProvider for testing', () => {
+      const sourceDeployCmd = child.spawnSync('sf', [
+        'project',
+        'deploy',
+        'start',
+        '-d',
+        path.join(__dirname, 'sfdx-source'),
+        '--json'
+      ]);
+      assert.deepStrictEqual(sourceDeployCmd.status, 0, sourceDeployCmd.output.toString());
+    });
+
+    it('should update multiple auth services', async () => {
+      await plugin.apply(configApplyMultiple);
+      const res = await plugin.retrieve(configApplyMultiple);
+      assert.deepStrictEqual(res, configApplyMultiple);
+    });
+
+    it('should throw an error when trying to apply a missing service', async () => {
+      let err;
+      try {
+        await plugin.apply(configApplyMissing);
+      } catch (e) {
+        err = e;
+      }
+      assert.throws(() => {
+        throw err;
+      }, /not found/);
     });
   });
 });

--- a/src/plugins/security/authentication-configuration/index.e2e-spec.ts
+++ b/src/plugins/security/authentication-configuration/index.e2e-spec.ts
@@ -36,6 +36,12 @@ describe(AuthenticationConfiguration.name, function () {
         { label: 'FakeAuthMethod', enabled: true }
       ]
     };
+    const resetTestState: Config = {
+      services: [
+        { label: 'Login Form', enabled: true },
+        { label: 'TestAuthMethod', enabled: false }
+      ]
+    };
 
     it('should retrieve the single enabled Login Form auth', async () => {
       const res = await plugin.retrieve(configRetrieveSingle);
@@ -88,5 +94,25 @@ describe(AuthenticationConfiguration.name, function () {
         throw err;
       }, /not found/);
     });
+
+    it('should reset auth services back to default', async () => {
+      await plugin.apply(resetTestState);
+      const res = await plugin.retrieve(resetTestState);
+      assert.deepStrictEqual(res, resetTestState);
+    });
+
+    it('should remove the testing AuthProvider', () => {
+      const sourceDeployCmd = child.spawnSync('sf', [
+        'project',
+        'delete',
+        'source',
+        '--metadata',
+        'AuthProvider:TestAuthMethod',
+        '--no-prompt',
+        '--json'
+      ]);
+      assert.deepStrictEqual(sourceDeployCmd.status, 0, sourceDeployCmd.output.toString());
+    });
+    
   });
 });

--- a/src/plugins/security/authentication-configuration/index.ts
+++ b/src/plugins/security/authentication-configuration/index.ts
@@ -1,0 +1,90 @@
+import { BrowserforcePlugin } from '../../../plugin.js';
+
+export type Config = {
+  services: Array<{
+    label: string;
+    enabled: boolean;
+  }>;
+};
+
+const PATHS = {
+  EDIT_VIEW: 'domainname/EditLogin.apexp'
+};
+
+const SELECTORS = {
+  SERVICE_CHECKBOX: 'input.authOption[type="checkbox"]',
+  SAVE_BUTTON: 'input[value="Save"]'
+};
+
+export class AuthenticationConfiguration extends BrowserforcePlugin {
+  public async retrieve(definition: Config): Promise<Config> {
+    const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
+
+    await page.waitForSelector(SELECTORS.SERVICE_CHECKBOX);
+
+    const services = await page.$$eval(
+      SELECTORS.SERVICE_CHECKBOX,
+      (inputs, definedServices) =>
+      (inputs as HTMLInputElement[])
+        .map((cb) => {
+        const labelElement = document.querySelector(`label[for="${cb.id}"]`);
+        const label = labelElement ? labelElement.textContent!.trim() : cb.id;
+        return {
+          label,
+          enabled: cb.checked
+        };
+        })
+        .filter((service) =>
+        definedServices.some((definedService) => definedService.label === service.label)
+        ),
+      definition.services
+    );
+
+    await page.close();
+    return { services };
+  }
+
+  public async apply(plan: Config): Promise<void> {
+    const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
+
+    await page.waitForSelector(SELECTORS.SERVICE_CHECKBOX);
+
+    for (const svc of plan.services) {
+      const checkboxId = await page.$$eval(
+        SELECTORS.SERVICE_CHECKBOX,
+        (inputs, serviceName) => {
+          for (const inp of inputs as HTMLInputElement[]) {
+            const labelElement = document.querySelector(`label[for="${inp.id}"]`);
+            if (labelElement && labelElement.textContent!.trim() === serviceName) {
+              return inp.id;
+            }
+          }
+          return null;
+        },
+        svc.label
+      ) as string | null;
+
+      if (!checkboxId) {
+        throw new Error(`Authentication service "${svc.label}" not found`);
+      }
+
+      const selector = `[id="${checkboxId}"]`;
+      const isChecked = await page.$eval(
+        selector,
+        (el) => (el as HTMLInputElement).checked
+      );
+
+      if (svc.enabled !== isChecked) {
+        await page.click(selector);
+      }
+    }
+
+    await page.waitForSelector(SELECTORS.SAVE_BUTTON);
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle0' }),
+      page.click(SELECTORS.SAVE_BUTTON)
+    ]);
+
+    await page.close();
+  }
+}

--- a/src/plugins/security/authentication-configuration/index.ts
+++ b/src/plugins/security/authentication-configuration/index.ts
@@ -52,10 +52,14 @@ export class AuthenticationConfiguration extends BrowserforcePlugin {
   public async apply(plan: Config): Promise<void> {
     const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
 
-    await page.waitForSelector(SELECTORS.SERVICE_CHECKBOX);
+    const frameOrPage = await this.browserforce.waitForSelectorInFrameOrPage(
+      page,
+      SELECTORS.SETUP_FORM
+    );
+    await frameOrPage.waitForSelector(SELECTORS.SERVICE_CHECKBOX);
 
     for (const svc of plan.services) {
-      const checkboxId = await page.$$eval(
+      const checkboxId = await frameOrPage.$$eval(
         SELECTORS.SERVICE_CHECKBOX,
         (inputs, serviceName) => {
           for (const inp of inputs as HTMLInputElement[]) {
@@ -74,20 +78,20 @@ export class AuthenticationConfiguration extends BrowserforcePlugin {
       }
 
       const selector = `[id="${checkboxId}"]`;
-      const isChecked = await page.$eval(
+      const isChecked = await frameOrPage.$eval(
         selector,
         (el) => (el as HTMLInputElement).checked
       );
 
       if (svc.enabled !== isChecked) {
-        await page.click(selector);
+        await frameOrPage.click(selector);
       }
     }
 
-    await page.waitForSelector(SELECTORS.SAVE_BUTTON);
+    await frameOrPage.waitForSelector(SELECTORS.SAVE_BUTTON);
     await Promise.all([
-      page.waitForNavigation({ waitUntil: 'networkidle0' }),
-      page.click(SELECTORS.SAVE_BUTTON)
+      frameOrPage.waitForNavigation({ waitUntil: 'networkidle0' }),
+      frameOrPage.click(SELECTORS.SAVE_BUTTON)
     ]);
 
     await page.close();

--- a/src/plugins/security/authentication-configuration/index.ts
+++ b/src/plugins/security/authentication-configuration/index.ts
@@ -14,7 +14,8 @@ const PATHS = {
 const SELECTORS = {
   SETUP_FORM: 'form[id="BrandSetup:brandSetupForm"]',
   SERVICE_CHECKBOX: 'input.authOption[type="checkbox"]',
-  SAVE_BUTTON: 'input[id$=":Save"]'
+  SAVE_BUTTON: 'input[id$=":Save"]',
+  ERROR_SPAN: '[id="BrandSetup:brandSetupForm:settingsDetail:es1:es14:authError"]'
 };
 
 export class AuthenticationConfiguration extends BrowserforcePlugin {
@@ -93,7 +94,16 @@ export class AuthenticationConfiguration extends BrowserforcePlugin {
       frameOrPage.waitForNavigation({ waitUntil: 'networkidle0' }),
       frameOrPage.click(SELECTORS.SAVE_BUTTON)
     ]);
-
+  try {
+    await frameOrPage.waitForSelector(SELECTORS.SAVE_BUTTON, { hidden: true, timeout: 1000 });
+  } catch {
+    const foundError = await frameOrPage.$(SELECTORS.ERROR_SPAN);
+    if (foundError) {
+      throw new Error(
+        'Change failed: “You must select at least one authentication service.”'
+      );
+    }
+  }
     await page.close();
   }
 }

--- a/src/plugins/security/authentication-configuration/index.ts
+++ b/src/plugins/security/authentication-configuration/index.ts
@@ -8,21 +8,26 @@ export type Config = {
 };
 
 const PATHS = {
-  EDIT_VIEW: 'domainname/EditLogin.apexp'
+  EDIT_VIEW: 'lightning/setup/OrgDomain/page?address=%2Fdomainname%2FEditLogin.apexp'
 };
 
 const SELECTORS = {
+  SETUP_FORM: 'form[id="BrandSetup:brandSetupForm"]',
   SERVICE_CHECKBOX: 'input.authOption[type="checkbox"]',
-  SAVE_BUTTON: 'input[value="Save"]'
+  SAVE_BUTTON: 'input[id$=":Save"]'
 };
 
 export class AuthenticationConfiguration extends BrowserforcePlugin {
   public async retrieve(definition: Config): Promise<Config> {
     const page = await this.browserforce.openPage(PATHS.EDIT_VIEW);
 
-    await page.waitForSelector(SELECTORS.SERVICE_CHECKBOX);
+   const frameOrPage = await this.browserforce.waitForSelectorInFrameOrPage(
+      page,
+      SELECTORS.SETUP_FORM
+    );
+    await frameOrPage.waitForSelector(SELECTORS.SERVICE_CHECKBOX);
 
-    const services = await page.$$eval(
+    const services = await frameOrPage.$$eval(
       SELECTORS.SERVICE_CHECKBOX,
       (inputs, definedServices) =>
       (inputs as HTMLInputElement[])

--- a/src/plugins/security/authentication-configuration/index.ts
+++ b/src/plugins/security/authentication-configuration/index.ts
@@ -89,21 +89,20 @@ export class AuthenticationConfiguration extends BrowserforcePlugin {
       }
     }
 
+    const anyChecked = await frameOrPage.$$eval(
+      SELECTORS.SERVICE_CHECKBOX,
+      (inputs) => (inputs as HTMLInputElement[]).some((cb) => cb.checked)
+    );
+    if (!anyChecked) {
+      throw new Error(
+        'Change failed: “You must select at least one authentication service.”'
+      );
+    }
     await frameOrPage.waitForSelector(SELECTORS.SAVE_BUTTON);
     await Promise.all([
       frameOrPage.waitForNavigation({ waitUntil: 'networkidle0' }),
       frameOrPage.click(SELECTORS.SAVE_BUTTON)
     ]);
-  try {
-    await frameOrPage.waitForSelector(SELECTORS.SAVE_BUTTON, { hidden: true, timeout: 1000 });
-  } catch {
-    const foundError = await frameOrPage.$(SELECTORS.ERROR_SPAN);
-    if (foundError) {
-      throw new Error(
-        'Change failed: “You must select at least one authentication service.”'
-      );
-    }
-  }
     await page.close();
   }
 }

--- a/src/plugins/security/authentication-configuration/schema.json
+++ b/src/plugins/security/authentication-configuration/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/security/authentication-configuration/schema.json",
+  "title": "Authentication Configuration",
+  "type": "object",
+  "properties": {
+    "services": {
+      "description": "List of Authentication Services to configure under My Domain, each with desired enabled state",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "The visible name of the authentication service"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "True to enable, false to disable"
+          }
+        },
+        "required": ["label", "enabled"]
+      },
+      "default": []
+    }
+  },
+  "required": ["services"]
+}

--- a/src/plugins/security/authentication-configuration/sfdx-source/authproviders/TestAuthMethod.authprovider
+++ b/src/plugins/security/authentication-configuration/sfdx-source/authproviders/TestAuthMethod.authprovider
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuthProvider xmlns="http://soap.sforce.com/2006/04/metadata">
+    <friendlyName>TestAuthMethod</friendlyName>
+    <includeOrgIdInIdentifier>true</includeOrgIdInIdentifier>
+    <isPkceEnabled>true</isPkceEnabled>
+    <providerType>Salesforce</providerType>
+    <requireMfa>false</requireMfa>
+    <sendAccessTokenInHeader>false</sendAccessTokenInHeader>
+    <sendClientCredentialsInHeader>false</sendClientCredentialsInHeader>
+    <sendSecretInApis>true</sendSecretInApis>
+</AuthProvider>

--- a/src/plugins/security/index.ts
+++ b/src/plugins/security/index.ts
@@ -6,12 +6,15 @@ import {
 import { IdentityProvider, Config as IdentityProviderConfig } from './identity-provider/index.js';
 import { LoginAccessPolicies, Config as LoginAccessPoliciesConfig } from './login-access-policies/index.js';
 import { Sharing, Config as SharingConfig } from './sharing/index.js';
+import { AuthenticationConfiguration, Config as AuthenticationConfigurationConfig} from './authentication-configuration/index.js';
+
 
 type Config = {
   certificateAndKeyManagement?: CertificateAndKeyManagementConfig;
   identityProvider?: IdentityProviderConfig;
   loginAccessPolicies?: LoginAccessPoliciesConfig;
   sharing?: SharingConfig;
+  authenticationConfiguration?: AuthenticationConfigurationConfig
 };
 
 export class Security extends BrowserforcePlugin {
@@ -34,6 +37,10 @@ export class Security extends BrowserforcePlugin {
         const pluginSharing = new Sharing(this.browserforce);
         response.sharing = await pluginSharing.retrieve();
       }
+      if (definition.authenticationConfiguration) {
+        response.authenticationConfiguration =
+            await new AuthenticationConfiguration(this.browserforce).retrieve(definition.authenticationConfiguration);
+      }
     }
     return response;
   }
@@ -52,6 +59,10 @@ export class Security extends BrowserforcePlugin {
       definition.loginAccessPolicies
     ) as LoginAccessPoliciesConfig | undefined;
     const sharing = new Sharing(this.browserforce).diff(state.sharing, definition.sharing) as SharingConfig | undefined;
+    const authenticationConfiguration = new AuthenticationConfiguration(this.browserforce).diff(
+        state.authenticationConfiguration,
+        definition.authenticationConfiguration
+      ) as AuthenticationConfigurationConfig | undefined;
     const response: Config = {};
     if (certificateAndKeyManagement !== undefined) {
       response.certificateAndKeyManagement = certificateAndKeyManagement;
@@ -67,6 +78,9 @@ export class Security extends BrowserforcePlugin {
     }
     if (sharing !== undefined) {
       response.sharing = sharing;
+    }
+    if (authenticationConfiguration !== undefined) {
+      response.authenticationConfiguration = authenticationConfiguration;
     }
     return Object.keys(response).length ? response : undefined;
   }
@@ -87,6 +101,10 @@ export class Security extends BrowserforcePlugin {
     if (plan.sharing) {
       const pluginSharing = new Sharing(this.browserforce);
       await pluginSharing.apply(plan.sharing);
+    }
+    if (plan.authenticationConfiguration) {
+      const pluginAuthConfig = new AuthenticationConfiguration(this.browserforce)
+      await pluginAuthConfig.apply(plan.authenticationConfiguration);
     }
   }
 }

--- a/src/plugins/security/schema.json
+++ b/src/plugins/security/schema.json
@@ -15,6 +15,9 @@
     },
     "sharing": {
       "$ref": "./sharing/schema.json"
+    },
+    "authenticationConfiguration": {
+      "$ref": "./authentication-configuration/schema.json"
     }
   }
 }


### PR DESCRIPTION
Attempt at solving #673 

This currently works for classic, but not lightning. The page seems to load lightning based on prior session visits to setup, so the (limited) e2e tests do not pass when running the whole suite. It also can't disable the default Login Form if there are no other services, so the todo is needing to insert a dummy Auth/Saml provider to have available for adding more test coverage. 

To fix the lightning issue, I dabbled with `waitForSelectorInFrameOrPage` and it worked for retrieval, but (oddly) only when using the debug delay.. I think the iframe may flash a few times confusing the DOM. Even with the delay it didn't like locating the checkboxes to enable, but that may have been user error. 

@amtrack If you have any tips for working in the iframe or forcing it to load in classic, I'm happy to keep tinkering - but if you want to approach another way I'll be happy just to have a working solution. 