### PR TITLE
feat: added user access policy activation, deactivation and trigger c…

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -8,6 +8,9 @@
       "enableOmniChannel": true,
       "enableOmniSkillsRouting": true,
       "enableOmniSecondaryRoutingPriority": true
+    },
+    "userManagementSettings": {
+      "userAccessPoliciesEnabled": true
     }
   }
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -21,7 +21,10 @@ import { Security as security } from './security/index.js';
 import { ServiceChannels as serviceChannels } from './service-channels/index.js';
 import { Slack as slack } from './slack/index.js';
 
+import { UserAccessPolicies as userAccessPolicies } from './user-access-policies/index.js';
+
 export {
+  userAccessPolicies,
   activitySettings,
   companyInformation,
   customerPortal,

--- a/src/plugins/schema.json
+++ b/src/plugins/schema.json
@@ -7,6 +7,9 @@
   "properties": {
     "settings": {
       "properties": {
+        "userAccessPolicies": {
+          "$ref": "./user-access-policies/schema.json"
+        },
         "salesforceCpqConfig": {
           "$ref": "./salesforce-cpq-config/schema.json"
         },

--- a/src/plugins/user-access-policies/activate.json
+++ b/src/plugins/user-access-policies/activate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "userAccessPolicies": {
+      "accessPolicies": [
+        {
+          "apiName": "Grant_Permissions",
+          "active": true
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/user-access-policies/change-trigger-type.json
+++ b/src/plugins/user-access-policies/change-trigger-type.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "userAccessPolicies": {
+      "accessPolicies": [
+        {
+          "apiName": "Grant_Permissions",
+          "active": true,
+          "on": "Create"
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/user-access-policies/deactivate.json
+++ b/src/plugins/user-access-policies/deactivate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "userAccessPolicies": {
+      "accessPolicies": [
+        {
+          "apiName": "Grant_Permissions",
+          "active": false
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/user-access-policies/index.e2e-spec.ts
+++ b/src/plugins/user-access-policies/index.e2e-spec.ts
@@ -1,0 +1,76 @@
+import assert from 'assert';
+import * as child from 'child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as path from 'path';
+import { UserAccessPolicies } from './index.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const readJsonFile = function (u: string) {
+  return JSON.parse(readFileSync(new URL(u, import.meta.url), 'utf8'));
+};
+
+describe(UserAccessPolicies.name, function () {
+  this.timeout('10m');
+  let plugin: UserAccessPolicies;
+  before(() => {
+    plugin = new UserAccessPolicies(global.bf);
+  });
+
+  const configActivate = readJsonFile('./activate.json').settings.userAccessPolicies;
+  const configDeactivate = readJsonFile('./deactivate.json').settings.userAccessPolicies;
+  const multiConfig = readJsonFile('./multiple-policies.json').settings.userAccessPolicies;
+  const changeTriggerConfig = readJsonFile('./change-trigger-type.json').settings.userAccessPolicies;
+
+  it('should deploy a CustomObject for testing', () => {
+    const sourceDeployCmd = child.spawnSync('sf', [
+      'project',
+      'deploy',
+      'start',
+      '-d',
+      path.join(__dirname, 'sfdx-source'),
+      '--json',
+    ]);
+    assert.deepStrictEqual(
+      sourceDeployCmd.status,
+      0,
+      sourceDeployCmd.output.toString()
+    );
+  });
+
+  it('should activate policy', async () => {
+    await plugin.run(configActivate);
+  });
+
+  it('should already be activated on default trigger type', async () => {
+    const res = await plugin.run(configActivate);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+
+  it('should deactivate policy', async () => {
+    await plugin.run(configDeactivate);
+  });
+
+  it('should already be deactivated', async () => {
+    const res = await plugin.run(configDeactivate);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+
+  it('should handle multiple policies', async () => {
+    await plugin.run(multiConfig);
+  });
+
+  it('should already have activated multiple policies on provided trigger types', async () => {
+    const res = await plugin.run(multiConfig);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+
+  it('should change trigger type of an already active policy', async () => {
+    await plugin.run(changeTriggerConfig);
+  });
+
+  it('should already be activated with the new trigger type', async () => {
+    const res = await plugin.run(changeTriggerConfig);
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+});

--- a/src/plugins/user-access-policies/index.ts
+++ b/src/plugins/user-access-policies/index.ts
@@ -1,0 +1,169 @@
+import { BrowserforcePlugin } from '../../plugin.js';
+import { UserAccessPoliciesPage } from './page.js';
+
+export type PolicyTriggerType = 'Create' | 'Update' | 'CreateAndUpdate';
+
+const DEFAULT_TRIGGER_TYPE: PolicyTriggerType = 'CreateAndUpdate';
+
+type AccessPolicy = {
+  apiName: string;
+  active: boolean;
+  on?: PolicyTriggerType;
+};
+
+export type Config = {
+  accessPolicies?: AccessPolicy[];
+};
+
+export class UserAccessPolicies extends BrowserforcePlugin {
+  private async queryPolicies(policyApiNames: string[]): Promise<{
+    policyStateMap: Map<string, boolean>;
+    policyIdMap: Map<string, string>;
+    policyTriggerTypeMap: Map<string, string | null>;
+  }> {
+    const quotedNames = policyApiNames.map((name) => `'${name}'`);
+    const query = `SELECT Id, DeveloperName, Status, TriggerType FROM UserAccessPolicy WHERE DeveloperName IN (${quotedNames.join(',')})`;
+
+    const queryResult = await this.org.getConnection().tooling.query(query);
+
+    const policyStateMap = new Map<string, boolean>();
+    const policyIdMap = new Map<string, string>();
+    const policyTriggerTypeMap = new Map<string, string | null>();
+
+    for (const record of queryResult.records as Array<{
+      Id: string;
+      DeveloperName: string;
+      Status: string;
+      TriggerType: string | null;
+    }>) {
+      policyStateMap.set(record.DeveloperName, record.Status === 'Active');
+      policyIdMap.set(record.DeveloperName, record.Id);
+      policyTriggerTypeMap.set(record.DeveloperName, record.TriggerType);
+    }
+
+    return { policyStateMap, policyIdMap, policyTriggerTypeMap };
+  }
+
+  public async retrieve(definition?: Config): Promise<Config> {
+    const response: Config = {
+      accessPolicies: [],
+    };
+
+    if (!definition?.accessPolicies || definition.accessPolicies.length === 0) {
+      return response;
+    }
+
+    const policyApiNames = definition.accessPolicies.map((policy) => policy.apiName);
+    const { policyStateMap, policyTriggerTypeMap } = await this.queryPolicies(policyApiNames);
+
+    for (const policy of definition.accessPolicies) {
+      const isActive = policyStateMap.get(policy.apiName) ?? false;
+      const triggerType = policyTriggerTypeMap.get(policy.apiName);
+      
+      const retrievedPolicy: AccessPolicy = {
+        apiName: policy.apiName,
+        active: isActive,
+      };
+      
+      if (policy.on !== undefined && isActive && triggerType) {
+        if (this.isValidTriggerType(triggerType)) {
+          retrievedPolicy.on = triggerType;
+        }
+      }
+      
+      response.accessPolicies!.push(retrievedPolicy);
+    }
+
+    return response;
+  }
+
+  public async apply(config: Config): Promise<void> {
+    if (!config.accessPolicies || config.accessPolicies.length === 0) {
+      return;
+    }
+
+    const policyApiNames = config.accessPolicies.map((policy) => policy.apiName);
+    const { policyStateMap, policyIdMap, policyTriggerTypeMap } = await this.queryPolicies(policyApiNames);
+
+    for (const policy of config.accessPolicies) {
+      const currentState = policyStateMap.get(policy.apiName) ?? false;
+      const policyId = policyIdMap.get(policy.apiName);
+      const currentTriggerType = policyTriggerTypeMap.get(policy.apiName);
+      
+      if (!policyId) {
+        throw new Error(`User Access Policy "${policy.apiName}" not found`);
+      }
+      
+      await this.applyPolicyChange(policy, policyId, currentState, currentTriggerType);
+    }
+  }
+
+  private isValidTriggerType(value: string | null | undefined): value is PolicyTriggerType {
+    return value === 'Create' || value === 'Update' || value === 'CreateAndUpdate';
+  }
+
+  private needsPolicyChange(
+    policy: AccessPolicy,
+    currentState: boolean,
+    currentTriggerType: string | null | undefined
+  ): boolean {
+    if (currentState !== policy.active) {
+      return true;
+    }
+    
+    if (!policy.active) {
+      return false;
+    }
+    
+    if (policy.on && currentTriggerType) {
+      return currentTriggerType !== policy.on;
+    }
+    
+    return false;
+  }
+
+  private async applyPolicyChange(
+    policy: AccessPolicy,
+    policyId: string,
+    currentState: boolean,
+    currentTriggerType: string | null | undefined
+  ): Promise<void> {
+    const needsChange = this.needsPolicyChange(policy, currentState, currentTriggerType);
+    
+    if (!needsChange) {
+      return;
+    }
+
+    const page = await this.browserforce.openPage(
+      UserAccessPoliciesPage.getPolicyUrl(policyId)
+    );
+    const policiesPage = new UserAccessPoliciesPage(page);
+
+    if (policy.active) {
+      const needsTriggerTypeChange = currentState && policy.on && currentTriggerType !== policy.on;
+      
+      if (needsTriggerTypeChange) {
+        await policiesPage.deactivatePolicy();
+        await page.close();
+
+        const newPage = await this.browserforce.openPage(
+          UserAccessPoliciesPage.getPolicyUrl(policyId)
+        );
+        const newPoliciesPage = new UserAccessPoliciesPage(newPage);
+        
+        await newPoliciesPage.activatePolicy(policy.on);
+        await newPage.close();
+      } else {
+        const triggerOn: PolicyTriggerType =
+          policy.on ||
+          (this.isValidTriggerType(currentTriggerType) ? currentTriggerType : DEFAULT_TRIGGER_TYPE);
+        
+        await policiesPage.activatePolicy(triggerOn);
+        await page.close();
+      }
+    } else {
+      await policiesPage.deactivatePolicy();
+      await page.close();
+    }
+  }
+}

--- a/src/plugins/user-access-policies/multiple-policies.json
+++ b/src/plugins/user-access-policies/multiple-policies.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "userAccessPolicies": {
+      "accessPolicies": [
+        {
+          "apiName": "Grant_Permissions",
+          "active": true,
+          "on": "Update"
+        },
+        {
+          "apiName": "Additional_Grant_Permissions",
+          "active": true,
+          "on": "Create"
+        }
+      ]
+    }
+  }
+}

--- a/src/plugins/user-access-policies/page.ts
+++ b/src/plugins/user-access-policies/page.ts
@@ -1,0 +1,169 @@
+import type { Page } from 'puppeteer';
+import { throwPageErrors } from '../../browserforce.js';
+
+export class UserAccessPoliciesPage {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  public static getPolicyUrl(policyId: string): string {
+    return `lightning/setup/UserAccessPolicies/${policyId}/view`;
+  }
+
+  /**
+   * Activate a policy from its detail page
+   * @param triggerOn - When to trigger the policy: 'Create', 'Update', or 'CreateAndUpdate' (default)
+   */
+  public async activatePolicy(triggerOn: 'Create' | 'Update' | 'CreateAndUpdate' = 'CreateAndUpdate'): Promise<void> {
+    try {
+      const xpath = '//button[contains(., "Automate Policy")]';
+      
+      let automateButton = null;
+      await this.page.waitForSelector(`::-p-xpath(${xpath})`, { timeout: 5000 });
+      const buttons = await this.page.$$(`xpath/.${xpath}`);
+      if (buttons.length > 0) {
+        automateButton = buttons[0];
+      }
+
+      if (!automateButton) {
+        throw new Error('Automate Policy button not found on page');
+      }
+
+      await this.waitForButtonEnabled(automateButton);
+
+      await automateButton.click();
+
+      await this.handleActivationModal(triggerOn);
+
+      await throwPageErrors(this.page);
+    } catch (error) {
+      throw new Error(`Failed to activate policy: ${error.message}`);
+    }
+  }
+
+  /**
+   * Deactivate a policy from its detail page
+   */
+  public async deactivatePolicy(): Promise<void> {
+    try {
+      const xpath = '//button[contains(., "Deactivate")]';
+      
+      let deactivateButton = null;
+      
+      await this.page.waitForSelector(`::-p-xpath(${xpath})`, { timeout: 5000 });
+      const buttons = await this.page.$$(`xpath/.${xpath}`);
+      if (buttons.length > 0) {
+        deactivateButton = buttons[0];
+      }
+      
+      if (!deactivateButton) {
+        throw new Error('Deactivate button not found on page');
+      }
+
+      await deactivateButton.click();
+
+      await this.handleConfirmationModal();
+
+      await throwPageErrors(this.page);
+    } catch (error) {
+      throw new Error(`Failed to deactivate policy: ${error.message}`);
+    }
+  }
+
+  /**
+   * Handle the activation modal (select trigger option and click Activate)
+   */
+  private async handleActivationModal(triggerOn: 'Create' | 'Update' | 'CreateAndUpdate'): Promise<void> {
+    const modalHeaderXpath = '//lightning-modal-header[contains(@class, "automate_policy_modal")]';
+    await this.page.waitForSelector(`::-p-xpath(${modalHeaderXpath})`, { timeout: 10000 });
+    
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    
+    const radioButtons = await this.page.$$('input[type="radio"]');
+    
+    if (radioButtons.length < 3) {
+      throw new Error('Modal did not load - radio buttons not found');
+    }
+
+    let radioButton = null;
+    for (const button of radioButtons) {
+      const value = await this.page.evaluate((radio) => radio.value, button);
+      if (value === triggerOn) {
+        radioButton = button;
+        break;
+      }
+    }
+    
+    if (!radioButton) {
+      throw new Error(`Radio button with value "${triggerOn}" not found`);
+    }
+    
+    const radioId = await this.page.evaluate((radio) => radio.id, radioButton);
+    
+    if (radioId) {
+      const label = await this.page.$(`label[for="${radioId}"]`);
+ 
+      await label.click();
+    }
+
+    const xpath = '//button[text()="Activate"] | //button[contains(text(), "Activate")]';
+    await this.page.waitForSelector(`::-p-xpath(${xpath})`, { timeout: 5000 });
+    const buttons = await this.page.$$(`xpath/.${xpath}`);
+    
+    if (buttons.length === 0) {
+      throw new Error('Activate button not found in modal');
+    }
+    
+    await buttons[0].click();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  /**
+   * Handle confirmation modal that may appear after deactivation
+   */
+  private async handleConfirmationModal(): Promise<void> {
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      
+      const xpath = '//lightning-modal-footer//button[text()="Deactivate"]';
+      await this.page.waitForSelector(`::-p-xpath(${xpath})`, { timeout: 5000 });
+      const buttons = await this.page.$$(`xpath/.${xpath}`);
+      
+      if (buttons.length === 0) {
+        throw new Error('Deactivate button not found in confirmation modal');
+      }
+
+      await buttons[0].click();
+      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } catch (e) {
+      throw new Error(`Failed to handle deactivation confirmation modal: ${e.message}`);
+    }
+  }
+
+  /**
+   * Wait for a button to become enabled
+   * @param button - The button element to wait for
+   * @param timeout - Maximum time to wait in milliseconds (default: 10000)
+   */
+  private async waitForButtonEnabled(button: any, timeout: number = 10000): Promise<void> {
+    const startTime = Date.now();
+    
+    while (Date.now() - startTime < timeout) {
+      const isDisabled = await this.page.evaluate((btn) => {
+        return btn.disabled;
+      }, button);
+      
+      if (!isDisabled) {
+        return;
+      }
+      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    
+    throw new Error(`Button did not become enabled within ${timeout}ms`);
+  }
+}

--- a/src/plugins/user-access-policies/schema.json
+++ b/src/plugins/user-access-policies/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/user-access-policies/schema.json",
+  "title": "User Access Policies",
+  "type": "object",
+  "properties": {
+    "accessPolicies": {
+      "title": "Access Policies",
+      "description": "List of user access policies to activate or deactivate",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/accessPolicy"
+      },
+      "default": []
+    }
+  },
+  "definitions": {
+    "accessPolicy": {
+      "type": "object",
+      "properties": {
+        "apiName": {
+          "type": "string",
+          "description": "The API name of the user access policy (e.g., 'Grant_Permissions')"
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Whether the policy should be active (true) or inactive (false)"
+        },
+        "on": {
+          "type": "string",
+          "description": "Optional: specify when to apply the policy - 'Create', 'Update', or 'CreateAndUpdate'",
+          "enum": ["Create", "Update", "CreateAndUpdate"]
+        }
+      },
+      "required": ["apiName", "active"]
+    }
+  }
+}

--- a/src/plugins/user-access-policies/sfdx-source/useraccesspolicies/Additional_Grant_Permissions.useraccesspolicy-meta.xml
+++ b/src/plugins/user-access-policies/sfdx-source/useraccesspolicies/Additional_Grant_Permissions.useraccesspolicy-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<UserAccessPolicy xmlns="http://soap.sforce.com/2006/04/metadata">
+    <booleanFilter>1</booleanFilter>
+    <masterLabel>Additional Grant Permissions</masterLabel>
+    <order>0</order>
+    <status>Active</status>
+    <userAccessPolicyActions>
+        <action>Revoke</action>
+        <target>force__SalesConsoleUser</target>
+        <type>PermissionSet</type>
+    </userAccessPolicyActions>
+    <userAccessPolicyFilters>
+        <operation>equals</operation>
+        <sortOrder>1</sortOrder>
+        <target>admin</target>
+        <type>Profile</type>
+    </userAccessPolicyFilters>
+</UserAccessPolicy>

--- a/src/plugins/user-access-policies/sfdx-source/useraccesspolicies/Grant_Permissions.useraccesspolicy-meta.xml
+++ b/src/plugins/user-access-policies/sfdx-source/useraccesspolicies/Grant_Permissions.useraccesspolicy-meta.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<UserAccessPolicy xmlns="http://soap.sforce.com/2006/04/metadata">
+    <booleanFilter>1</booleanFilter>
+    <masterLabel>Grant Permissions</masterLabel>
+    <order>0</order>
+    <status>Active</status>
+    <userAccessPolicyActions>
+        <action>Revoke</action>
+        <target>force__SalesConsoleUser</target>
+        <type>PermissionSet</type>
+    </userAccessPolicyActions>
+    <userAccessPolicyFilters>
+        <operation>equals</operation>
+        <sortOrder>1</sortOrder>
+        <target>admin</target>
+        <type>Profile</type>
+    </userAccessPolicyFilters>
+</UserAccessPolicy>


### PR DESCRIPTION
Any deployment to an existing and active User Access Policy will deactivate the policy, no matter what status you set in the metadata. This plugin allows you to set the correct status and trigger type for User Access Policies.

Main Features:
- activate inactive User Access Policies
- deactivate active User Access Policies
- update the trigger type of an Access Policy (Deactivate+Activate)

@amtrack Thank you for this great framework 😄 