### PR TITLE
fix: make some features language agnostic

### DIFF
--- a/src/plugins/linkedin-sales-navigator-settings/page.ts
+++ b/src/plugins/linkedin-sales-navigator-settings/page.ts
@@ -4,9 +4,9 @@ import { throwPageErrors } from '../../browserforce.js';
 const ENABLE_TOGGLE =
   'div[data-aura-class="setup_sales_linkedinLinkedInSetupRow"] input[type="checkbox"]:not(:disabled)';
 const CONFIRM_CHECKBOX =
-  'lightning-input lightning-primitive-input-checkbox input[name="LinkedIn Sales Navigator Integration Acceptance Checkbox"]:not(:disabled)';
+  'section[role="dialog"] lightning-input lightning-primitive-input-checkbox input:not(:disabled)';
 const ACCEPT_BUTTON =
-  'section[data-aura-class="setup_sales_linkedinLinkedInSetupAcceptTermsModal"] div div button:not(:disabled):nth-child(2)';
+  'section[role="dialog"] div div button:not(:disabled):nth-child(2)';
 
 export class LinkedInSalesNavigatorPage {
   private page: Page;


### PR DESCRIPTION
Where possible, we should make the features independent of the language of the user.
This means using selectors based on ids, names or even DOM structure rather than labels.

This is related to #720 .