### PR TITLE
refactor: remove deprecated --targetusername flag

### DIFF
--- a/src/browserforce-command.ts
+++ b/src/browserforce-command.ts
@@ -1,4 +1,4 @@
-import { Flags, SfCommand, Ux, requiredOrgFlagWithDeprecations } from '@salesforce/sf-plugins-core';
+import { Flags, SfCommand, Ux } from '@salesforce/sf-plugins-core';
 import { promises } from 'fs';
 import * as path from 'path';
 import { Browserforce } from './browserforce.js';
@@ -9,7 +9,7 @@ import * as DRIVERS from './plugins/index.js';
 export abstract class BrowserforceCommand<T> extends SfCommand<T> {
   static baseFlags = {
     ...SfCommand.baseFlags,
-    'target-org': requiredOrgFlagWithDeprecations,
+    'target-org': Flags.requiredOrg(),
     definitionfile: Flags.string({
       char: 'f',
       description: 'path to a browserforce state file',


### PR DESCRIPTION
The --targetusername (-u) flag was deprecated in favor of the standardized --target-org (-o) flag used across Salesforce CLI commands.

BREAKING CHANGE: The --targetusername (-u) flag has been removed.

Use --target-org (-o) instead.