### PR TITLE
feat: add Einstein Bots plugin to enable/disable Einstein Bots

### DIFF
--- a/src/plugins/einstein-bots/disable.json
+++ b/src/plugins/einstein-bots/disable.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "einsteinBots": {
+      "enabled": false
+    }
+  }
+}
+

--- a/src/plugins/einstein-bots/enable.json
+++ b/src/plugins/einstein-bots/enable.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "einsteinBots": {
+      "enabled": true
+    }
+  }
+}
+

--- a/src/plugins/einstein-bots/index.e2e-spec.ts
+++ b/src/plugins/einstein-bots/index.e2e-spec.ts
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import { EinsteinBots } from './index.js';
+
+describe(EinsteinBots.name, function () {
+  this.timeout('10m');
+  let plugin: EinsteinBots;
+  before(() => {
+    plugin = new EinsteinBots(global.browserforce);
+  });
+
+  const configEnabled = {
+    enabled: true,
+  };
+  const configDisabled = {
+    enabled: false,
+  };
+
+  it('should enable Einstein Bots', async () => {
+    await plugin.run(configEnabled);
+  });
+
+  it('should verify Einstein Bots is enabled', async () => {
+    const res = await plugin.retrieve();
+    assert.deepStrictEqual(res, configEnabled);
+  });
+
+  it('should disable Einstein Bots', async () => {
+    await plugin.run(configDisabled);
+  });
+
+  it('should verify Einstein Bots is disabled', async () => {
+    const res = await plugin.retrieve();
+    assert.deepStrictEqual(res, configDisabled);
+  });
+});
+

--- a/src/plugins/einstein-bots/index.ts
+++ b/src/plugins/einstein-bots/index.ts
@@ -1,0 +1,48 @@
+import { BrowserforcePlugin } from '../../plugin.js';
+
+const BASE_PATH = '/lightning/setup/EinsteinBots/home';
+
+// The checkbox input element (for reading state and clicking)
+const TOGGLE_INPUT_SELECTOR = 'input[type="checkbox"][aria-label*="Einstein Bots"]';
+
+type Config = {
+  enabled: boolean;
+};
+
+export class EinsteinBots extends BrowserforcePlugin {
+  public async retrieve(): Promise<Config> {
+    await using page = await this.browserforce.openPage(BASE_PATH);
+    await page.locator(TOGGLE_INPUT_SELECTOR).waitFor();
+    const response = {
+      enabled: await page.locator(TOGGLE_INPUT_SELECTOR).isChecked(),
+    };
+    return response;
+  }
+
+  public async apply(config: Config): Promise<void> {
+    await using page = await this.browserforce.openPage(BASE_PATH);
+    await page.locator(TOGGLE_INPUT_SELECTOR).waitFor();
+    const currentState = await page.locator(TOGGLE_INPUT_SELECTOR).isChecked();
+    // Only click if the state needs to change
+    if (currentState !== config.enabled) {
+      if (!config.enabled) {
+        // When disabling, click the toggle and wait for the confirmation dialog
+        await page.locator(TOGGLE_INPUT_SELECTOR).click({ force: true });
+
+        // Wait for the "Disable Einstein Bots" dialog and click Yes
+        const disableDialog = page.getByRole('dialog', { name: 'Disable Einstein Bots' });
+        await disableDialog.waitFor({ timeout: 5000 });
+        await disableDialog.getByRole('button', { name: 'Yes' }).click();
+
+        // Wait for the dialog to close (this is when the save happens)
+        await disableDialog.waitFor({ state: 'hidden', timeout: 10000 });
+      } else {
+        // When enabling, just click the toggle
+        await page.locator(TOGGLE_INPUT_SELECTOR).click({ force: true });
+      }
+
+      // Wait for the save to complete
+      await page.waitForTimeout(2000);
+    }
+  }
+}

--- a/src/plugins/einstein-bots/schema.json
+++ b/src/plugins/einstein-bots/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/einstein-bots/schema.json",
+  "title": "Einstein Bots",
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "title": "Einstein Bots",
+      "description": "Enable or disable Einstein Bots. Setup -> Einstein Bots -> Einstein Bots toggle.",
+      "type": "boolean"
+    }
+  }
+}
+

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -2,6 +2,7 @@ import { ActivitySettings as activitySettings } from './activity-settings/index.
 import { CompanyInformation as companyInformation } from './company-information/index.js';
 import { CustomerPortal as customerPortal } from './customer-portal/index.js';
 import { DensitySettings as densitySettings } from './density-settings/index.js';
+import { EinsteinBots as einsteinBots } from './einstein-bots/index.js';
 import { EmailDeliverability as emailDeliverability } from './email-deliverability/index.js';
 import { HighVelocitySalesSettings as highVelocitySalesSettings } from './high-velocity-sales-settings/index.js';
 import { HistoryTracking as historyTracking } from './history-tracking/index.js';
@@ -27,6 +28,7 @@ export {
   companyInformation,
   customerPortal,
   densitySettings,
+  einsteinBots,
   emailDeliverability,
   highVelocitySalesSettings,
   historyTracking,

--- a/src/plugins/schema.json
+++ b/src/plugins/schema.json
@@ -46,6 +46,9 @@
         "densitySettings": {
           "$ref": "./density-settings/schema.json"
         },
+        "einsteinBots": {
+          "$ref": "./einstein-bots/schema.json"
+        },
         "historyTracking": {
           "$ref": "./history-tracking/schema.json"
         },


### PR DESCRIPTION
## Summary

Add a new plugin to enable/disable Einstein Bots in Salesforce Setup.

## Description

This plugin automates the Einstein Bots toggle found at **Setup → Einstein Bots → Einstein Bots toggle**.

### Features
- `retrieve()` - Checks the current enabled/disabled state of Einstein Bots
- `apply()` - Enables or disables Einstein Bots based on configuration
- Handles the confirmation dialog that appears when disabling Einstein Bots

### Configuration

**Enable Einstein Bots:**

```json
{
  "settings": {
    "einsteinBots": {
      "enabled": true
    }
  }
}
```

**Disable Einstein Bots:**

```json
{
  "settings": {
    "einsteinBots": {
      "enabled": false
    }
  }
}
```

## Testing

- [x] Unit tests pass (`npm test`)
- [x] Manual testing: Enable works in headless mode
- [x] Manual testing: Disable works in headless mode (handles confirmation dialog)
- [x] E2E test spec included

## Checklist

- [x] Follows existing plugin patterns
- [x] Includes schema.json for config validation
- [x] Includes example config files (enable.json, disable.json)
- [x] Includes e2e test spec
- [x] Exported in src/plugins/index.ts
- [x] Referenced in src/plugins/schema.json