### PR TITLE
Fix Login timeout when redirected to Salesforce maintenance

### DIFF
--- a/src/pages/login.ts
+++ b/src/pages/login.ts
@@ -15,6 +15,10 @@ export class LoginPage {
     const org = await Org.create({ connection });
     const frontDoorUrl = await org.getFrontDoorUrl(POST_LOGIN_PATH);
     await this.page.goto(frontDoorUrl);
+    const currentUrl = new URL(this.page.url());
+    if (currentUrl.pathname === '/msg/maintenanceandavailable.jsp') {
+      await this.page.goto(currentUrl.origin + POST_LOGIN_PATH);
+    }
     await Promise.race([this.page.waitForURL((url) => url.pathname === POST_LOGIN_PATH), waitForPageErrors(this.page)]);
     return this;
   }


### PR DESCRIPTION
Implemented a login flow fix for Salesforce maintenance-page redirects.

Changes in this branch:
1. Updated login.ts to detect when post-login navigation lands on `/msg/maintenanceandavailable.jsp`.
2. When that maintenance page appears, the flow now immediately navigates back to the target post-login path (`/setup/forcecomHomepage.apexp`) using the same org origin.
3. This prevents the login process from getting stuck waiting on the wrong page and reduces the `page.waitForURL` timeout failures during maintenance-window redirects.

Scope:
1. Only login.ts is changed in this branch.

Fixes #736