### PR TITLE
Added WebAuthn passkey command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ coverage/
 
 # Playwright traces
 trace-*.zip
+
+# Exported WebAuthn credentials contain the authenticator's PRIVATE KEY.
+# Treat these exactly like a password. Never commit them.
+sf-passkey-*.json

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ apply a plan from a config file
 ```
 USAGE
   $ sf browserforce apply -o <value> [--json] [--flags-dir <value>] [-f <value>] [-d] [--headless] [--slow-mo <value>]
-    [--timeout <value>] [--trace] [--browser-executable-path <value>] [--browser-channel <value>] [--max-retries
-    <value>] [--retry-timeout <value>]
+    [--timeout <value>] [--trace] [--browser-executable-path <value>] [--browser-channel <value>] [--passkey-credential
+    <value>] [--max-retries <value>] [--retry-timeout <value>]
 
 FLAGS
   -d, --dry-run                 [env: BROWSERFORCE_DRY_RUN] dry run
@@ -150,6 +150,8 @@ BROWSER CONFIGURATION FLAGS
   --browser-channel=<value>          [env: BROWSERFORCE_BROWSER_CHANNEL] the channel (e.g. chromium or chrome) to use
   --browser-executable-path=<value>  [env: BROWSERFORCE_BROWSER_EXECUTABLE_PATH] the path to a browser executable
   --[no-]headless                    [env: BROWSERFORCE_HEADLESS] run in headless mode (default: true)
+  --passkey-credential=<value>       [env: BROWSERFORCE_PASSKEY_CREDENTIAL] path to a passkey credential file to use for
+                                     the login
   --slow-mo=<value>                  [env: BROWSERFORCE_SLOWMO] slow motion in milliseconds (default: 0)
   --timeout=<value>                  [default: 90000, env: BROWSERFORCE_NAVIGATION_TIMEOUT_MS] the default navigation
                                      timeout in milliseconds
@@ -190,6 +192,14 @@ FLAG DESCRIPTIONS
 
     Note: The environment variable CHROME_BIN can also be used. On GitHub Actions with ubuntu-latest, CHROME_BIN is set
     to /usr/bin/google-chrome.
+
+  --passkey-credential=<value>  path to a passkey credential file to use for the login
+
+    The credential is loaded into a virtual authenticator before the login, so that a passkey challenge (e.g. from an
+    untrusted CI IP) could be answered.
+    This is unverified best-effort: it is inert unless Salesforce actually challenges the passkey, and server side
+    acceptance has not been confirmed.
+    '<host>' in the path is replaced by the org hostname. The file contains a private key and is password-equivalent.
 
   --trace  create a Playwright trace file
 

--- a/src/browserforce-command.ts
+++ b/src/browserforce-command.ts
@@ -6,8 +6,17 @@ import * as path from 'path';
 import { chromium } from 'playwright';
 import { Browserforce, type BrowserforceOptions } from './browserforce.js';
 import { ConfigParser } from './config-parser.js';
+import { type LoginOptions } from './pages/login.js';
 import { handleDeprecations } from './plugins/deprecated.js';
 import * as DRIVERS from './plugins/index.js';
+import {
+  readCredentialFile,
+  resolveCredentialFilePath,
+  withSignCountHeadroom,
+} from './plugins/passkey/credential-file.js';
+import { VirtualAuthenticator } from './plugins/passkey/virtual-authenticator.js';
+
+const PASSKEY_PLUGIN_KEY = 'passkey';
 
 export abstract class BrowserforceCommand<T> extends SfCommand<T> {
   static baseFlags = {
@@ -63,6 +72,14 @@ export abstract class BrowserforceCommand<T> extends SfCommand<T> {
       description: 'Playwright will try to figure out the path to the browser executable automatically.',
       env: 'BROWSERFORCE_BROWSER_CHANNEL',
     }),
+    'passkey-credential': Flags.string({
+      helpGroup: 'Browser Configuration',
+      summary: 'path to a passkey credential file to use for the login',
+      description: `The credential is loaded into a virtual authenticator before the login, so that a passkey challenge (e.g. from an untrusted CI IP) could be answered.
+This is unverified best-effort: it is inert unless Salesforce actually challenges the passkey, and server side acceptance has not been confirmed. Do not rely on it as MFA.
+'<host>' in the path is replaced by the org hostname. The file contains a private key and is password-equivalent.`,
+      env: 'BROWSERFORCE_PASSKEY_CREDENTIAL',
+    }),
     // retry config
     'max-retries': Flags.integer({
       helpGroup: 'Retry Configuration',
@@ -107,9 +124,39 @@ export abstract class BrowserforceCommand<T> extends SfCommand<T> {
 
     this.spinner.start('logging in');
     await this.browserforce.browserContext.tracing.group('login');
-    await this.browserforce.login();
+    await this.loginToOrg(flags['passkey-credential'], {
+      // only the passkey plugin can get past a forced passkey enrollment
+      tolerateEnrollmentGate: this.settings.some((setting) => setting.key === PASSKEY_PLUGIN_KEY),
+    });
     this.spinner.stop();
     await this.browserforce.browserContext.tracing.groupEnd();
+  }
+
+  private async loginToOrg(passkeyCredentialFile: string | undefined, options: LoginOptions): Promise<void> {
+    if (!passkeyCredentialFile) {
+      await this.browserforce.login(options);
+      return;
+    }
+    const host = new URL(this.browserforce.getInstanceUrl()).host;
+    const credentialFile = resolveCredentialFilePath(passkeyCredentialFile, host);
+    const file = await readCredentialFile(credentialFile);
+    if (!file) {
+      throw new Error(`Passkey credential file '${credentialFile}' not found`);
+    }
+    if (file.rpId !== host) {
+      throw new Error(
+        `Passkey credential file '${credentialFile}' belongs to '${file.rpId}', but this org is '${host}'`,
+      );
+    }
+    const page = await this.browserforce.browserContext.newPage();
+    try {
+      // exactly ONE virtual authenticator holding exactly this credential:
+      // a stray empty one would intercept the assertion and fail it
+      await VirtualAuthenticator.attach(page, [withSignCountHeadroom(file.credential)]);
+      await this.browserforce.loginOnPage(page, options);
+    } finally {
+      await page.close();
+    }
   }
 
   public async finally(err?: Error): Promise<void> {

--- a/src/browserforce.ts
+++ b/src/browserforce.ts
@@ -2,7 +2,7 @@ import { type Connection } from '@salesforce/core';
 import { type Ux } from '@salesforce/sf-plugins-core';
 import pRetry, { Options as RetryOptions } from 'p-retry';
 import { type BrowserContext, type FrameLocator, type Page } from 'playwright';
-import { LoginPage } from './pages/login.js';
+import { LoginPage, type LoginOptions } from './pages/login.js';
 
 const VF_IFRAME_SELECTOR = 'force-aloha-page iframe[name^=vfFrameId]';
 
@@ -28,11 +28,21 @@ export class Browserforce {
     };
   }
 
-  public async login(): Promise<Browserforce> {
+  public async login(options?: LoginOptions): Promise<Browserforce> {
     await using page = await this.browserContext.newPage();
-    const loginPage = new LoginPage(page);
-    await loginPage.login(this.connection);
+    await this.loginOnPage(page, options);
     return this;
+  }
+
+  /**
+   * Logs in on an existing page instead of a throwaway one, e.g. to keep the
+   * page a Virtual Authenticator is attached to, or to inspect where the login
+   * landed.
+   */
+  public async loginOnPage(page: Page, options?: LoginOptions): Promise<Page> {
+    const loginPage = new LoginPage(page);
+    await loginPage.login(this.connection, options);
+    return page;
   }
 
   // path instead of url

--- a/src/pages/login.ts
+++ b/src/pages/login.ts
@@ -4,6 +4,42 @@ import { waitForPageErrors } from '../browserforce.js';
 
 const POST_LOGIN_PATH = '/setup/forcecomHomepage.apexp';
 
+/**
+ * Identity interstitials Salesforce can redirect a login to.
+ *
+ * These are undocumented internals (see docs/adr/0001), but the login waits for
+ * the post login path only, so it has to recognize them to fail fast instead of
+ * hanging until the navigation timeout.
+ */
+const ENROLLMENT_GATE_PATH_PREFIX = '/_ui/identity/webauthn/';
+const VERIFICATION_PATH_PREFIX = '/_ui/identity/verification/';
+
+/**
+ * The forced passkey enrollment interstitial ("Enrollment Gate",
+ * e.g. /_ui/identity/webauthn/AddPasskeyUi) intercepting the login of a user
+ * with zero passkey Registrations.
+ */
+export function isEnrollmentGateUrl(url: URL): boolean {
+  return url.pathname.startsWith(ENROLLMENT_GATE_PATH_PREFIX);
+}
+
+/**
+ * An identity verification interstitial ("Verify Your Identity",
+ * e.g. /_ui/identity/verification/method/UnifiedPasskeyVerificationUi)
+ * requiring a WebAuthn assertion or another second factor.
+ */
+export function isVerificationUrl(url: URL): boolean {
+  return url.pathname.startsWith(VERIFICATION_PATH_PREFIX);
+}
+
+export type LoginOptions = {
+  /**
+   * Resolve instead of failing when the login is intercepted by the passkey
+   * Enrollment Gate. Only the passkey plugin can do anything useful there.
+   */
+  tolerateEnrollmentGate?: boolean;
+};
+
 export class LoginPage {
   private page: Page;
 
@@ -11,7 +47,7 @@ export class LoginPage {
     this.page = page;
   }
 
-  async login(connection: Connection) {
+  async login(connection: Connection, options?: LoginOptions) {
     const org = await Org.create({ connection });
     const frontDoorUrl = await org.getFrontDoorUrl(POST_LOGIN_PATH);
     await this.page.goto(frontDoorUrl);
@@ -19,7 +55,40 @@ export class LoginPage {
     if (currentUrl.pathname === '/msg/maintenanceandavailable.jsp') {
       await this.page.goto(currentUrl.origin + POST_LOGIN_PATH);
     }
-    await Promise.race([this.page.waitForURL((url) => url.pathname === POST_LOGIN_PATH), waitForPageErrors(this.page)]);
+    await Promise.race([
+      this.page.waitForURL((url) => url.pathname === POST_LOGIN_PATH),
+      this.waitForIdentityInterstitial(options),
+      waitForPageErrors(this.page),
+    ]);
     return this;
+  }
+
+  /**
+   * Identity interstitials are neither the post login page nor a page error, so
+   * without this the login would hang until the navigation timeout.
+   */
+  private async waitForIdentityInterstitial(options?: LoginOptions): Promise<void> {
+    let interstitial: 'enrollmentGate' | 'verification' | undefined;
+    await this.page.waitForURL((url) => {
+      if (isEnrollmentGateUrl(url)) {
+        interstitial = 'enrollmentGate';
+      } else if (isVerificationUrl(url)) {
+        interstitial = 'verification';
+      }
+      return interstitial !== undefined;
+    });
+    if (interstitial === 'enrollmentGate') {
+      if (options?.tolerateEnrollmentGate) {
+        return;
+      }
+      throw new Error(
+        `The login was intercepted by the passkey enrollment gate (${this.page.url()}), because this user has no passkey (Built-in Authenticator) yet.
+👉 Please see the 'passkey' Browserforce setting to register one for a dedicated automation user.`,
+      );
+    }
+    throw new Error(
+      `The login was intercepted by an identity verification page (${this.page.url()}), which Browserforce cannot complete.
+👉 If a passkey credential was injected using --passkey-credential, Salesforce did not accept it.`,
+    );
   }
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -12,6 +12,7 @@ import { ListViewCustomButtons as listViewCustomButtons } from './list-view-cust
 import { LinkedInSalesNavigatorSettings as linkedInSalesNavigatorSettings } from './linkedin-sales-navigator-settings/index.js';
 import { OmniChannelSettings as omniChannelSettings } from './omni-channel-settings/index.js';
 import { OpportunitySplits as opportunitySplits } from './opportunity-splits/index.js';
+import { Passkey as passkey } from './passkey/index.js';
 import { PermissionSets as permissionSets } from './permission-sets/index.js';
 import { Picklists as picklists } from './picklists/index.js';
 import { RecordTypes as recordTypes } from './record-types/index.js';
@@ -39,6 +40,7 @@ export {
   linkedInSalesNavigatorSettings,
   omniChannelSettings,
   opportunitySplits,
+  passkey,
   permissionSets,
   picklists,
   recordTypes,

--- a/src/plugins/passkey/credential-file.test.ts
+++ b/src/plugins/passkey/credential-file.test.ts
@@ -1,0 +1,124 @@
+import assert from 'assert';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  assertPasskeyCredentialFile,
+  decodeBase64url,
+  readCredentialFile,
+  resolveCredentialFilePath,
+  withSignCountHeadroom,
+  writeCredentialFile,
+  type PasskeyCredentialFile,
+} from './credential-file.js';
+
+const RP_ID = 'acme--dev.sandbox.my.salesforce.com';
+
+const file: PasskeyCredentialFile = {
+  rpId: RP_ID,
+  registrationId: '0moRR0000000uzt',
+  credential: {
+    credentialId: 'dGVzdC1jcmVkZW50aWFsLWlk',
+    isResidentCredential: true,
+    rpId: RP_ID,
+    privateKey: 'dGVzdC1wcml2YXRlLWtleQ',
+    signCount: 1,
+  },
+};
+
+describe('resolveCredentialFilePath', () => {
+  it('should replace the <host> placeholder with the org hostname', () => {
+    assert.strictEqual(resolveCredentialFilePath('./sf-passkey-<host>.json', RP_ID), `./sf-passkey-${RP_ID}.json`);
+  });
+  it('should leave a path without a placeholder alone', () => {
+    assert.strictEqual(resolveCredentialFilePath('./passkey.json', RP_ID), './passkey.json');
+  });
+});
+
+describe('readCredentialFile/writeCredentialFile', () => {
+  let directory: string;
+  before(async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'browserforce-passkey-'));
+  });
+  after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+
+  it('should round trip the Credential and its Registration id', async () => {
+    const credentialFile = path.join(directory, 'sub', 'passkey.json');
+    await writeCredentialFile(credentialFile, file);
+    assert.deepStrictEqual(await readCredentialFile(credentialFile), file);
+  });
+  it('should return undefined when nothing is held yet', async () => {
+    assert.strictEqual(await readCredentialFile(path.join(directory, 'missing.json')), undefined);
+  });
+  it('should fail on a file that is not JSON', async () => {
+    const credentialFile = path.join(directory, 'garbage.json');
+    await fs.writeFile(credentialFile, 'not json');
+    await assert.rejects(() => readCredentialFile(credentialFile), /Failed parsing passkey credential file/);
+  });
+});
+
+describe('assertPasskeyCredentialFile', () => {
+  const invalid: Array<{ description: string; value: unknown; expected: RegExp }> = [
+    { description: 'not an object', value: 'nope', expected: /expected a JSON object/ },
+    { description: 'missing rpId', value: { ...file, rpId: undefined }, expected: /'rpId' must be the org hostname/ },
+    {
+      description: 'a Registration id that is not a passkey',
+      value: { ...file, registrationId: '0PS000000000000' },
+      expected: /'registrationId' must be a passkey Registration id \(0mo\)/,
+    },
+    {
+      description: 'a missing credential',
+      value: { ...file, credential: undefined },
+      expected: /'credential' must be an exported WebAuthn credential/,
+    },
+    {
+      description: 'a missing signCount',
+      value: { ...file, credential: { ...file.credential, signCount: undefined } },
+      expected: /'credential.signCount' must be a number/,
+    },
+    {
+      description: 'an empty private key',
+      value: { ...file, credential: { ...file.credential, privateKey: '' } },
+      expected: /'credential.privateKey' must be a base64url encoded string/,
+    },
+    {
+      description: 'a credential id that is not base64url',
+      value: { ...file, credential: { ...file.credential, credentialId: 'not base64!' } },
+      expected: /'credential.credentialId' is not base64url encoded/,
+    },
+  ];
+  it('should accept a valid file', () => {
+    assert.deepStrictEqual(assertPasskeyCredentialFile(file, 'passkey.json'), file);
+  });
+  for (const t of invalid) {
+    it(`should reject ${t.description}`, () => {
+      assert.throws(() => assertPasskeyCredentialFile(t.value, 'passkey.json'), t.expected);
+    });
+  }
+});
+
+describe('decodeBase64url', () => {
+  it('should decode base64', () => {
+    assert.deepStrictEqual(decodeBase64url('AQID'), new Uint8Array([1, 2, 3]));
+  });
+  it('should decode the base64url alphabet', () => {
+    assert.deepStrictEqual(decodeBase64url('-_8'), new Uint8Array([251, 255]));
+  });
+  it('should decode a padded value', () => {
+    assert.deepStrictEqual(decodeBase64url('AQ=='), new Uint8Array([1]));
+  });
+  it('should reject invalid characters', () => {
+    assert.throws(() => decodeBase64url('not base64!'), /is not base64url encoded/);
+  });
+  it('should reject an impossible length', () => {
+    assert.throws(() => decodeBase64url('AQIDA'), /is not base64url encoded/);
+  });
+});
+
+describe('withSignCountHeadroom', () => {
+  it('should leave headroom for assertions we did not observe', () => {
+    assert.strictEqual(withSignCountHeadroom(file.credential).signCount, 101);
+  });
+});

--- a/src/plugins/passkey/credential-file.ts
+++ b/src/plugins/passkey/credential-file.ts
@@ -1,0 +1,112 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { REGISTRATION_ID_PREFIX } from './registrations.js';
+import { type VirtualAuthenticatorCredential } from './virtual-authenticator.js';
+
+/**
+ * The persisted passkey: the client side Credential together with the id of
+ * the server side Registration it belongs to.
+ *
+ * ⚠️ Contains the authenticator private key and is password-equivalent. Keep it
+ * out of version control and treat it as a secret. It is only valid for the org
+ * it was created for (rpId is the org hostname) and dies on a sandbox refresh.
+ */
+export type PasskeyCredentialFile = {
+  rpId: string;
+  registrationId: string;
+  credential: VirtualAuthenticatorCredential;
+};
+
+/**
+ * Credentials are only valid for one org, so a config shared across orgs needs
+ * one file per org. `<host>` in the configured path is replaced by the org
+ * hostname (which is the rpId).
+ */
+export function resolveCredentialFilePath(credentialFile: string, host: string): string {
+  return credentialFile.split('<host>').join(host);
+}
+
+/**
+ * Salesforce increments the signature counter on every assertion. A vaulted
+ * counter can be behind the server's, which looks like a cloned authenticator,
+ * so leave headroom when injecting (the POC scripts do the same).
+ */
+const SIGN_COUNT_HEADROOM = 100;
+
+export function withSignCountHeadroom(credential: VirtualAuthenticatorCredential): VirtualAuthenticatorCredential {
+  return { ...credential, signCount: credential.signCount + SIGN_COUNT_HEADROOM };
+}
+
+/**
+ * @returns undefined when the file does not exist (nothing is held yet)
+ */
+export async function readCredentialFile(credentialFile: string): Promise<PasskeyCredentialFile | undefined> {
+  let contents: string;
+  try {
+    contents = await fs.readFile(path.resolve(credentialFile), 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (err) {
+    throw new Error(`Failed parsing passkey credential file '${credentialFile}'`);
+  }
+  return assertPasskeyCredentialFile(parsed, credentialFile);
+}
+
+export async function writeCredentialFile(credentialFile: string, file: PasskeyCredentialFile): Promise<void> {
+  const filePath = path.resolve(credentialFile);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  // 0o600: password-equivalent (no effect on Windows)
+  await fs.writeFile(filePath, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function assertPasskeyCredentialFile(value: unknown, credentialFile: string): PasskeyCredentialFile {
+  const invalid = (message: string) => new Error(`Invalid passkey credential file '${credentialFile}': ${message}`);
+  if (typeof value !== 'object' || value === null) {
+    throw invalid('expected a JSON object');
+  }
+  const file = value as Partial<PasskeyCredentialFile>;
+  if (typeof file.rpId !== 'string' || !file.rpId.length) {
+    throw invalid(`'rpId' must be the org hostname`);
+  }
+  if (typeof file.registrationId !== 'string' || !file.registrationId.startsWith(REGISTRATION_ID_PREFIX)) {
+    throw invalid(`'registrationId' must be a passkey Registration id (${REGISTRATION_ID_PREFIX})`);
+  }
+  const credential = file.credential;
+  if (typeof credential !== 'object' || credential === null) {
+    throw invalid(`'credential' must be an exported WebAuthn credential`);
+  }
+  if (typeof credential.signCount !== 'number') {
+    throw invalid(`'credential.signCount' must be a number`);
+  }
+  for (const key of ['credentialId', 'privateKey'] as const) {
+    const encoded = credential[key];
+    if (typeof encoded !== 'string' || !encoded.length) {
+      throw invalid(`'credential.${key}' must be a base64url encoded string`);
+    }
+    try {
+      decodeBase64url(encoded);
+    } catch (err) {
+      throw invalid(`'credential.${key}' is not base64url encoded`);
+    }
+  }
+  return file as PasskeyCredentialFile;
+}
+
+/**
+ * Decodes a base64url (or plain base64) encoded value, as used for the
+ * credential id and the private key.
+ */
+export function decodeBase64url(encoded: string): Uint8Array {
+  const base64 = encoded.split('-').join('+').split('_').join('/').replace(/=+$/, '');
+  if (!/^[A-Za-z0-9+/]*$/.test(base64) || base64.length % 4 === 1) {
+    throw new Error(`'${encoded}' is not base64url encoded`);
+  }
+  return new Uint8Array(Buffer.from(base64, 'base64'));
+}

--- a/src/plugins/passkey/decision.test.ts
+++ b/src/plugins/passkey/decision.test.ts
@@ -1,0 +1,134 @@
+import assert from 'assert';
+import { decide, partitionRegistrations, type PasskeyConfig, type PasskeyPlan, type PasskeyState } from './decision.js';
+
+const OURS = '0moRR0000000uzt';
+const FOREIGN = '0moRR0000000v37';
+const CREDENTIAL_FILE = './sf-passkey-acme.my.salesforce.com.json';
+
+function state(partial: Partial<PasskeyState> = {}): PasskeyState {
+  const registrationIds = partial.registrationIds ?? [];
+  const heldRegistrationId = 'heldRegistrationId' in partial ? partial.heldRegistrationId : undefined;
+  return {
+    registrationIds,
+    heldRegistrationId,
+    registered:
+      partial.registered ?? (heldRegistrationId !== undefined && registrationIds.includes(heldRegistrationId)),
+  };
+}
+
+type T = {
+  description: string;
+  state: PasskeyState;
+  config: PasskeyConfig;
+  expected: PasskeyPlan;
+};
+
+const tests: T[] = [
+  {
+    description: 'should enroll when the user has no Registration',
+    state: state(),
+    config: { registered: true, credentialFile: CREDENTIAL_FILE },
+    expected: { action: 'enroll', credentialFile: CREDENTIAL_FILE },
+  },
+  {
+    description: 'should enroll without persisting the Credential when no credentialFile is configured',
+    state: state(),
+    config: { registered: true },
+    expected: { action: 'enroll', credentialFile: undefined },
+  },
+  {
+    description: 'should do nothing when a Registration we hold the Credential for exists',
+    state: state({ registrationIds: [OURS], heldRegistrationId: OURS }),
+    config: { registered: true, credentialFile: CREDENTIAL_FILE },
+    expected: { action: 'none' },
+  },
+  {
+    description: 'should do nothing when our Registration coexists with a foreign one',
+    state: state({ registrationIds: [FOREIGN, OURS], heldRegistrationId: OURS }),
+    config: { registered: true, credentialFile: CREDENTIAL_FILE },
+    expected: { action: 'none' },
+  },
+  {
+    description: 'should refuse to enroll when a Registration we do not hold the Credential for exists',
+    state: state({ registrationIds: [FOREIGN], heldRegistrationId: OURS }),
+    config: { registered: true, credentialFile: CREDENTIAL_FILE },
+    expected: {
+      action: 'refuse',
+      reason: `refusing to touch the passkey Registration(s) ${FOREIGN} of this user: the Credential in '${CREDENTIAL_FILE}' does not match it. A human may own it. Set 'force': true in the passkey settings to delete it anyway, but only if this user is a dedicated automation user.`,
+    },
+  },
+  {
+    description: 'should replace a foreign Registration when force is set',
+    state: state({ registrationIds: [FOREIGN], heldRegistrationId: OURS }),
+    config: { registered: true, credentialFile: CREDENTIAL_FILE, force: true },
+    expected: { action: 'replace', registrationIds: [FOREIGN], credentialFile: CREDENTIAL_FILE },
+  },
+  {
+    description: 'should delete our Registration',
+    state: state({ registrationIds: [OURS], heldRegistrationId: OURS }),
+    config: { registered: false, credentialFile: CREDENTIAL_FILE },
+    expected: { action: 'delete', registrationIds: [OURS] },
+  },
+  {
+    description: 'should do nothing when there is no Registration to delete',
+    state: state({ heldRegistrationId: OURS }),
+    config: { registered: false, credentialFile: CREDENTIAL_FILE },
+    expected: { action: 'none' },
+  },
+  {
+    description: 'should refuse to delete a Registration we do not hold the Credential for',
+    state: state({ registrationIds: [FOREIGN], heldRegistrationId: OURS }),
+    config: { registered: false, credentialFile: CREDENTIAL_FILE },
+    expected: {
+      action: 'refuse',
+      reason: `refusing to touch the passkey Registration(s) ${FOREIGN} of this user: the Credential in '${CREDENTIAL_FILE}' does not match it. A human may own it. Set 'force': true in the passkey settings to delete it anyway, but only if this user is a dedicated automation user.`,
+    },
+  },
+  {
+    description: 'should refuse to delete any Registration when no credentialFile is configured',
+    state: state({ registrationIds: [FOREIGN] }),
+    config: { registered: false },
+    expected: {
+      action: 'refuse',
+      reason: `refusing to touch the passkey Registration(s) ${FOREIGN} of this user: no 'credentialFile' is configured, so no Registration can be recognized as ours. A human may own it. Set 'force': true in the passkey settings to delete it anyway, but only if this user is a dedicated automation user.`,
+    },
+  },
+  {
+    description: 'should delete all Registrations when force is set',
+    state: state({ registrationIds: [FOREIGN, OURS], heldRegistrationId: OURS }),
+    config: { registered: false, credentialFile: CREDENTIAL_FILE, force: true },
+    expected: { action: 'delete', registrationIds: [FOREIGN, OURS] },
+  },
+  {
+    description: 'should refuse when registered is missing',
+    state: state(),
+    config: {} as PasskeyConfig,
+    expected: {
+      action: 'refuse',
+      reason: `the passkey setting 'registered' is required and must be a boolean, but was 'undefined'`,
+    },
+  },
+];
+
+describe('decide', () => {
+  for (const t of tests) {
+    it(t.description, () => {
+      assert.deepStrictEqual(decide(t.state, t.config), t.expected);
+    });
+  }
+});
+
+describe('partitionRegistrations', () => {
+  it('should treat a Registration without a held Credential as foreign', () => {
+    assert.deepStrictEqual(partitionRegistrations(state({ registrationIds: [FOREIGN] })), {
+      ours: [],
+      foreign: [FOREIGN],
+    });
+  });
+  it('should separate ours from foreign ones', () => {
+    assert.deepStrictEqual(
+      partitionRegistrations(state({ registrationIds: [FOREIGN, OURS], heldRegistrationId: OURS })),
+      { ours: [OURS], foreign: [FOREIGN] },
+    );
+  });
+});

--- a/src/plugins/passkey/decision.ts
+++ b/src/plugins/passkey/decision.ts
@@ -1,0 +1,93 @@
+/**
+ * The pure decision logic of the passkey plugin: given the passkey
+ * Registrations of the user and the Credential we hold, what has to happen?
+ *
+ * See docs/adr/0001-passkey-plugin-exactly-one-on-dedicated-privileged-user.md
+ */
+
+export type PasskeyConfig = {
+  /**
+   * The desired state, sharpened: `true` means "a Registration exists that we
+   * hold the Credential for", not merely "a Registration exists".
+   */
+  registered: boolean;
+  /**
+   * Where the Credential of the Registration is stored (contains the private
+   * key). Without it, no Registration can ever be recognized as ours.
+   */
+  credentialFile?: string;
+  /**
+   * Delete a Registration whose Credential we do not hold (a human may own it).
+   */
+  force?: boolean;
+};
+
+export type PasskeyState = {
+  /** whether a Registration we hold the Credential for exists */
+  registered: boolean;
+  /** all Registration ids of the user (empty at the Enrollment Gate) */
+  registrationIds: string[];
+  /** the Registration id of the Credential we hold, if any */
+  heldRegistrationId?: string;
+};
+
+export type PasskeyPlan =
+  | { action: 'none' }
+  | { action: 'enroll'; credentialFile?: string }
+  | { action: 'delete'; registrationIds: string[] }
+  | { action: 'replace'; registrationIds: string[]; credentialFile?: string }
+  | { action: 'refuse'; reason: string };
+
+/**
+ * Splits the Registrations of the user into the one we hold the Credential for
+ * and the ones we do not (which may belong to a human).
+ */
+export function partitionRegistrations(state: PasskeyState): { ours: string[]; foreign: string[] } {
+  const isOurs = (registrationId: string) => registrationId === state.heldRegistrationId;
+  return {
+    ours: state.registrationIds.filter(isOurs),
+    foreign: state.registrationIds.filter((registrationId) => !isOurs(registrationId)),
+  };
+}
+
+export function decide(state: PasskeyState, config: PasskeyConfig): PasskeyPlan {
+  if (typeof config.registered !== 'boolean') {
+    return {
+      action: 'refuse',
+      reason: `the passkey setting 'registered' is required and must be a boolean, but was '${JSON.stringify(config.registered)}'`,
+    };
+  }
+  const { ours, foreign } = partitionRegistrations(state);
+  if (config.registered) {
+    if (ours.length) {
+      // desired state reached, even if a foreign Registration coexists
+      return { action: 'none' };
+    }
+    if (!foreign.length) {
+      return { action: 'enroll', credentialFile: config.credentialFile };
+    }
+    if (!config.force) {
+      return { action: 'refuse', reason: refuseReason(foreign, config) };
+    }
+    return { action: 'replace', registrationIds: foreign, credentialFile: config.credentialFile };
+  }
+  if (!state.registrationIds.length) {
+    return { action: 'none' };
+  }
+  if (foreign.length && !config.force) {
+    return { action: 'refuse', reason: refuseReason(foreign, config) };
+  }
+  return { action: 'delete', registrationIds: state.registrationIds };
+}
+
+function refuseReason(foreign: string[], config: PasskeyConfig): string {
+  const held = config.credentialFile
+    ? `the Credential in '${config.credentialFile}' does not match ${foreign.length > 1 ? 'any of them' : 'it'}`
+    : `no 'credentialFile' is configured, so no Registration can be recognized as ours`;
+  return [
+    `refusing to touch the passkey Registration(s) ${foreign.join(', ')} of this user:`,
+    `${held}.`,
+    `A human may own it. Set 'force': true in the passkey settings to delete it anyway,`,
+    `but only if this user is a dedicated automation user.`,
+  ].join(' ');
+}

--- a/src/plugins/passkey/delete.json
+++ b/src/plugins/passkey/delete.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "passkey": {
+      "registered": false,
+      "credentialFile": "./sf-passkey-<host>.json"
+    }
+  }
+}

--- a/src/plugins/passkey/index.e2e-spec.ts
+++ b/src/plugins/passkey/index.e2e-spec.ts
@@ -1,0 +1,71 @@
+import assert from 'assert';
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readCredentialFile, resolveCredentialFilePath } from './credential-file.js';
+import { type Config, Passkey } from './index.js';
+
+/**
+ * Requires a DEDICATED automation user without a passkey (see the ADRs). The
+ * spec enrolls a passkey and deletes it again, leaving the user as it was found.
+ */
+describe(Passkey.name, function () {
+  let plugin: Passkey;
+  let directory: string;
+  let credentialFile: string;
+  let rpId: string;
+
+  before(async () => {
+    directory = await fs.mkdtemp(path.join(os.tmpdir(), 'browserforce-passkey-e2e-'));
+    credentialFile = path.join(directory, 'sf-passkey-<host>.json');
+    rpId = new URL(global.browserforce.getInstanceUrl()).host;
+  });
+  after(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  beforeEach(() => {
+    plugin = new Passkey(global.browserforce);
+  });
+  afterEach(async () => {
+    await plugin.close();
+  });
+
+  const configRegistered = (): Config => ({ registered: true, credentialFile });
+  const configUnregistered = (): Config => ({ registered: false, credentialFile });
+
+  it('should start without a passkey', async () => {
+    const state = await plugin.retrieve(configRegistered());
+    assert.deepStrictEqual(state.registrationIds, [], 'this user already has a passkey, please delete it first');
+  });
+
+  it('should register a passkey and save its credential', async () => {
+    await plugin.run(configRegistered());
+    const state = await plugin.retrieve(configRegistered());
+    assert.strictEqual(state.registrationIds.length, 1);
+    assert.strictEqual(state.registered, true);
+    const file = await readCredentialFile(resolveCredentialFilePath(credentialFile, rpId));
+    assert.strictEqual(file?.rpId, rpId);
+    assert.strictEqual(file?.registrationId, state.registrationIds[0]);
+    assert.ok(file?.credential.privateKey.length, 'expected the credential to hold a private key');
+  });
+
+  it('should already be registered', async () => {
+    const res = await plugin.run(configRegistered());
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+
+  it('should refuse to delete a passkey whose credential it does not hold', async () => {
+    await assert.rejects(() => plugin.run({ registered: false }), /refusing to touch the passkey Registration/);
+  });
+
+  it('should delete the passkey', async () => {
+    await plugin.run(configUnregistered());
+    const state = await plugin.retrieve(configUnregistered());
+    assert.deepStrictEqual(state.registrationIds, []);
+  });
+
+  it('should already be deleted', async () => {
+    const res = await plugin.run(configUnregistered());
+    assert.deepStrictEqual(res, { message: 'no action necessary' });
+  });
+});

--- a/src/plugins/passkey/index.ts
+++ b/src/plugins/passkey/index.ts
@@ -1,0 +1,323 @@
+import { type Page } from 'playwright';
+import { type SalesforceUrlPath } from '../../browserforce.js';
+import { isEnrollmentGateUrl } from '../../pages/login.js';
+import { BrowserforcePlugin } from '../../plugin.js';
+import { readCredentialFile, resolveCredentialFilePath, writeCredentialFile } from './credential-file.js';
+import { decide, partitionRegistrations, type PasskeyConfig, type PasskeyPlan, type PasskeyState } from './decision.js';
+import { parseRegistrationCount, parseRegistrationId } from './registrations.js';
+import { VirtualAuthenticator } from './virtual-authenticator.js';
+
+export type Config = PasskeyConfig;
+export type State = PasskeyState;
+export type Plan = PasskeyPlan;
+
+const CREATE_PASSKEY_BUTTON = /create passkey/i;
+// the voluntary "Register" link of the Built-in Authenticators related list,
+// which goes straight to the create ceremony while the user has no Registration
+const REGISTER_LINK = 'a[href*="registrationInterstitial.apexp"]';
+const REGISTRATION_DELETE_LINK = 'a[href*="delID=0mo"]';
+const CLASSIC_PAGE_BLOCK = '.bPageBlock';
+
+const ENROLLMENT_TIMEOUT_MS = 60_000;
+const DELETION_TIMEOUT_MS = 60_000;
+const POLL_INTERVAL_MS = 2_000;
+
+/**
+ * Registers (or deletes) the single passkey of a dedicated automation user.
+ *
+ * ⚠️ Only point this at a user reserved for automation. Salesforce requires an
+ * assertion against an existing passkey to add a second one, which no
+ * automation can do for a passkey it does not hold, so a human passkey and an
+ * automation passkey cannot coexist on one user.
+ *
+ * See docs/adr/0001-passkey-plugin-exactly-one-on-dedicated-privileged-user.md
+ * and CONTEXT.md for the vocabulary (Credential vs Registration vs Gate).
+ */
+export class Passkey extends BrowserforcePlugin {
+  /** the page the Virtual Authenticator is attached to (the enrollment ceremony needs it) */
+  private authenticatorPage?: Page;
+  private authenticator?: VirtualAuthenticator;
+  private atEnrollmentGate = false;
+
+  public async retrieve(definition?: Config): Promise<State> {
+    const held = await this.readHeldCredential(definition);
+    await this.openAuthenticatorSession();
+    // A user with zero Registrations cannot reach any post login page, so the
+    // Enrollment Gate itself is the definitive "zero Registrations" signal.
+    const registrationIds = this.atEnrollmentGate ? [] : await this.getRegistrationIds();
+    return {
+      registrationIds,
+      heldRegistrationId: held?.registrationId,
+      registered: held !== undefined && registrationIds.includes(held.registrationId),
+    };
+  }
+
+  /**
+   * `credentialFile` and `force` are inputs, not state, so the generic deep
+   * diff would always report a change. The plan is the decision instead.
+   */
+  public diff(state: State, definition: Config): Plan | undefined {
+    const plan = decide(state, this.normalize(definition));
+    if (plan.action === 'refuse') {
+      throw new Error(plan.reason);
+    }
+    if (plan.action === 'none') {
+      const { foreign } = partitionRegistrations(state);
+      if (foreign.length) {
+        this.browserforce.logger?.warn(
+          `this user also has the passkey Registration(s) ${foreign.join(', ')}, whose Credential we do not hold`,
+        );
+      }
+      return undefined;
+    }
+    return plan;
+  }
+
+  public async apply(plan: Plan): Promise<void> {
+    switch (plan.action) {
+      case 'none':
+        return;
+      case 'refuse':
+        throw new Error(plan.reason);
+      case 'enroll':
+        await this.enroll(plan.credentialFile);
+        return;
+      case 'delete':
+        await this.deleteRegistrations(plan.registrationIds);
+        return;
+      case 'replace':
+        // enrolling requires zero Registrations (no assertion step-up there)
+        await this.deleteRegistrations(plan.registrationIds);
+        await this.enroll(plan.credentialFile);
+        return;
+    }
+  }
+
+  public async run(definition: unknown): Promise<unknown> {
+    try {
+      return await super.run(definition);
+    } finally {
+      await this.close();
+    }
+  }
+
+  public async close(): Promise<void> {
+    await this.authenticatorPage?.close();
+    this.authenticatorPage = undefined;
+    this.authenticator = undefined;
+    this.atEnrollmentGate = false;
+  }
+
+  private normalize(definition: Config): Config {
+    return {
+      ...definition,
+      credentialFile: this.getCredentialFilePath(definition),
+    };
+  }
+
+  private getCredentialFilePath(definition?: Config): string | undefined {
+    if (!definition?.credentialFile) {
+      return undefined;
+    }
+    return resolveCredentialFilePath(definition.credentialFile, this.getRpId());
+  }
+
+  /** the Relying Party id of the org, which is its hostname */
+  private getRpId(): string {
+    return new URL(this.browserforce.getInstanceUrl()).host;
+  }
+
+  private async readHeldCredential(definition?: Config) {
+    const credentialFile = this.getCredentialFilePath(definition);
+    if (!credentialFile) {
+      return undefined;
+    }
+    const file = await readCredentialFile(credentialFile);
+    if (!file) {
+      return undefined;
+    }
+    if (file.rpId !== this.getRpId()) {
+      // a Credential is bound to the org hostname and dies on a sandbox refresh
+      this.browserforce.logger?.warn(
+        `ignoring the passkey credential file '${credentialFile}': it belongs to '${file.rpId}', but this org is '${this.getRpId()}'`,
+      );
+      return undefined;
+    }
+    return file;
+  }
+
+  /**
+   * Logs in on a page with a Virtual Authenticator attached, tolerating the
+   * Enrollment Gate (which is where the enrollment ceremony happens).
+   */
+  private async openAuthenticatorSession(): Promise<Page> {
+    if (this.authenticatorPage) {
+      return this.authenticatorPage;
+    }
+    const page = await this.browserforce.browserContext.newPage();
+    // exactly ONE Virtual Authenticator, see docs/adr/0002
+    this.authenticator = await VirtualAuthenticator.attach(page);
+    await this.browserforce.loginOnPage(page, { tolerateEnrollmentGate: true });
+    this.authenticatorPage = page;
+    this.atEnrollmentGate = isEnrollmentGateUrl(new URL(page.url()));
+    return page;
+  }
+
+  private async getUserDetailPath(): Promise<SalesforceUrlPath> {
+    const identity = await this.browserforce.connection.identity();
+    // the passkey has no API representation and only surfaces on the classic
+    // user detail page (undocumented internals)
+    return `/${identity.user_id}?noredirect=1&isUserEntityOverride=1`;
+  }
+
+  private async getRegistrationIds(): Promise<string[]> {
+    await using page = await this.browserforce.openPage(await this.getUserDetailPath());
+    await page.locator(CLASSIC_PAGE_BLOCK).first().waitFor();
+    const registrationIds: string[] = [];
+    for (const link of await page.locator(REGISTRATION_DELETE_LINK).all()) {
+      registrationIds.push(parseRegistrationId(await link.getAttribute('href')));
+    }
+    const count = parseRegistrationCount(await page.locator('body').innerText());
+    if (count === undefined) {
+      this.browserforce.logger?.warn(
+        `could not find the 'Built-in Authenticators' related list on the user detail page, relying on ${registrationIds.length} delete link(s)`,
+      );
+    } else if (count !== registrationIds.length) {
+      throw new Error(
+        `found ${count} passkey Registration(s) on the user detail page, but ${registrationIds.length} delete link(s). Refusing to guess which one to manage.`,
+      );
+    }
+    return registrationIds;
+  }
+
+  private async enroll(credentialFile?: string): Promise<void> {
+    const page = await this.openAuthenticatorSession();
+    const authenticator = this.authenticator;
+    if (!authenticator) {
+      throw new Error('no Virtual Authenticator attached');
+    }
+    if (!this.atEnrollmentGate) {
+      await this.openVoluntaryEnrollment(page);
+    }
+    const credentialsBefore = (await authenticator.getCredentials()).length;
+    const urlBeforeCreate = page.url();
+    await page.getByRole('button', { name: CREATE_PASSKEY_BUTTON }).click();
+    await waitUntil(async () => (await authenticator.getCredentials()).length > credentialsBefore, {
+      timeoutMs: ENROLLMENT_TIMEOUT_MS,
+      description: 'the Virtual Authenticator to create a Credential',
+    });
+    this.atEnrollmentGate = false;
+    // The ceremony posts the attestation to Salesforce and navigates on, which
+    // is when the Registration exists and the Enrollment Gate is cleared.
+    try {
+      await page.waitForURL((url) => url.href !== urlBeforeCreate, { timeout: ENROLLMENT_TIMEOUT_MS / 3 });
+    } catch (err) {
+      // the voluntary enrollment path may not navigate at all
+    }
+    const registrationIds = await waitUntil(
+      async () => {
+        const ids = await this.getRegistrationIds();
+        return ids.length ? ids : undefined;
+      },
+      { timeoutMs: ENROLLMENT_TIMEOUT_MS, description: 'the passkey Registration to appear' },
+    );
+    if (registrationIds.length !== 1) {
+      throw new Error(`expected exactly one passkey Registration after enrolling, but found ${registrationIds.length}`);
+    }
+    const credentials = await authenticator.getCredentials();
+    if (credentials.length !== 1) {
+      throw new Error(`expected exactly one Credential in the Virtual Authenticator, but found ${credentials.length}`);
+    }
+    this.browserforce.logger?.log(`registered the passkey ${registrationIds[0]}`);
+    if (!credentialFile) {
+      // The private key dies with the browser process. The Registration stays
+      // valid (Salesforce does not assert it on a frontdoor login), but nobody
+      // can ever use it again, and only 'force' can replace it.
+      this.browserforce.logger?.warn(
+        `no 'credentialFile' configured: the Credential of ${registrationIds[0]} is discarded and this Registration can never be recognized as ours again`,
+      );
+      return;
+    }
+    await writeCredentialFile(credentialFile, {
+      rpId: this.getRpId(),
+      registrationId: registrationIds[0],
+      credential: credentials[0],
+    });
+    this.browserforce.logger?.log(`saved the Credential to '${credentialFile}' (⚠️ contains a private key)`);
+  }
+
+  /**
+   * When the org does not force enrollment at login, the Registration has to be
+   * created from the user detail page. While the user has no Registration, this
+   * goes straight to the create ceremony without an assertion step-up.
+   */
+  private async openVoluntaryEnrollment(page: Page): Promise<void> {
+    const instanceUrl = this.browserforce.getInstanceUrl();
+    await page.goto(`${instanceUrl}${await this.getUserDetailPath()}`);
+    await page.locator(CLASSIC_PAGE_BLOCK).first().waitFor();
+    const registerLink = page.locator(REGISTER_LINK).last();
+    if (!(await registerLink.count())) {
+      throw new Error(
+        `could not find a link to register a passkey on the user detail page. Does this user have permission to manage its own Built-in Authenticators?`,
+      );
+    }
+    await registerLink.click();
+    await page.getByRole('button', { name: CREATE_PASSKEY_BUTTON }).waitFor();
+  }
+
+  private async deleteRegistrations(registrationIds: string[]): Promise<void> {
+    for (const registrationId of registrationIds) {
+      await this.deleteRegistration(registrationId);
+      this.browserforce.logger?.log(`deleted the passkey Registration ${registrationId}`);
+    }
+  }
+
+  private async deleteRegistration(registrationId: string): Promise<void> {
+    await using page = await this.browserforce.openPage(await this.getUserDetailPath());
+    await page.locator(CLASSIC_PAGE_BLOCK).first().waitFor();
+    const deleteLink = page.locator(`a[href*="delID=${registrationId}"]`);
+    if ((await deleteLink.count()) !== 1) {
+      throw new Error(
+        `expected exactly one delete link for the passkey Registration ${registrationId}, but found ${await deleteLink.count()}`,
+      );
+    }
+    // guard against deleting the wrong record (see poc/README.md)
+    parseRegistrationId(await deleteLink.getAttribute('href'));
+    page.on('dialog', (dialog) => dialog.accept());
+    await deleteLink.click();
+    // the page navigates back to the user detail view even when nothing was
+    // deleted, so verify against the server instead of trusting the navigation
+    await waitUntil(async () => !(await this.getRegistrationIds()).includes(registrationId), {
+      timeoutMs: DELETION_TIMEOUT_MS,
+      description: `the passkey Registration ${registrationId} to be gone`,
+    });
+  }
+}
+
+/**
+ * Polls until the action returns something other than undefined or false.
+ * Errors are retried, because the pages involved briefly redirect while
+ * Salesforce settles a passkey change.
+ */
+async function waitUntil<T>(
+  action: () => Promise<T | undefined | false>,
+  options: { timeoutMs: number; description: string },
+): Promise<T> {
+  const deadline = Date.now() + options.timeoutMs;
+  let lastError: unknown;
+  do {
+    try {
+      const result = await action();
+      if (result !== undefined && result !== false) {
+        return result;
+      }
+      lastError = undefined;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  } while (Date.now() < deadline);
+  throw new Error(`Timed out after ${options.timeoutMs}ms waiting for ${options.description}`, {
+    cause: lastError instanceof Error ? lastError : undefined,
+  });
+}

--- a/src/plugins/passkey/register.json
+++ b/src/plugins/passkey/register.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../schema.json",
+  "settings": {
+    "passkey": {
+      "registered": true,
+      "credentialFile": "./sf-passkey-<host>.json"
+    }
+  }
+}

--- a/src/plugins/passkey/registrations.test.ts
+++ b/src/plugins/passkey/registrations.test.ts
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import { parseRegistrationCount, parseRegistrationId } from './registrations.js';
+
+describe('parseRegistrationId', () => {
+  it('should parse the Registration id of a passkey delete link', () => {
+    assert.strictEqual(
+      parseRegistrationId('/setup/secur/RemoteAccessAuthorizationPage.apexp?delID=0moRR0000000uzt&retURL=%2F005'),
+      '0moRR0000000uzt',
+    );
+  });
+  it('should refuse the delete link of another related list', () => {
+    // this mis-click removed a permission set assignment during the POC
+    assert.throws(
+      () => parseRegistrationId('/p/setup/perm/PermSetAssignment?delID=0Pa000000000000'),
+      /refusing to click the delete link .*: the record id '0Pa000000000000' is not a passkey Registration \(0mo\)/,
+    );
+  });
+  it('should fail on a link without a delID', () => {
+    assert.throws(() => parseRegistrationId('/005RR000000abcd'), /could not parse a delID/);
+  });
+  it('should fail on a missing href', () => {
+    assert.throws(() => parseRegistrationId(null), /could not parse a delID/);
+  });
+});
+
+describe('parseRegistrationCount', () => {
+  it('should read the related list count', () => {
+    assert.strictEqual(parseRegistrationCount('Permission Set Assignments[3]\nBuilt-in Authenticators[2]\n'), 2);
+  });
+  it('should read a count of zero', () => {
+    assert.strictEqual(parseRegistrationCount('Built-in Authenticators[0]'), 0);
+  });
+  it('should return undefined when the related list is not rendered', () => {
+    assert.strictEqual(parseRegistrationCount('Permission Set Assignments[3]'), undefined);
+  });
+});

--- a/src/plugins/passkey/registrations.ts
+++ b/src/plugins/passkey/registrations.ts
@@ -1,0 +1,34 @@
+/**
+ * A passkey Registration is the server side record ("Built-in Authenticators"
+ * related list on the classic user detail page). Its id has the `0mo` prefix.
+ */
+export const REGISTRATION_ID_PREFIX = '0mo';
+
+/**
+ * The classic user detail page renders a `Del` link for many related lists
+ * (permission sets, licenses, ...). Clicking the wrong one deletes the wrong
+ * record (this actually happened during the POC, see poc/README.md), so the
+ * record id prefix is asserted before a link is ever clicked.
+ */
+export function parseRegistrationId(href: string | null | undefined): string {
+  const id = /[?&]delID=([a-zA-Z0-9]+)/.exec(href ?? '')?.[1];
+  if (id === undefined) {
+    throw new Error(`could not parse a delID from the delete link href '${href}'`);
+  }
+  if (!id.startsWith(REGISTRATION_ID_PREFIX)) {
+    throw new Error(
+      `refusing to click the delete link '${href}': the record id '${id}' is not a passkey Registration (${REGISTRATION_ID_PREFIX})`,
+    );
+  }
+  return id;
+}
+
+/**
+ * The number of rows Salesforce reports for the related list, e.g.
+ * "Built-in Authenticators[2]". Used to cross check the delete links found.
+ * @returns undefined when the related list is not rendered (e.g. localized)
+ */
+export function parseRegistrationCount(pageText: string): number | undefined {
+  const count = /Built-in Authenticators\s*\[(\d+)\]/.exec(pageText)?.[1];
+  return count === undefined ? undefined : Number(count);
+}

--- a/src/plugins/passkey/schema.json
+++ b/src/plugins/passkey/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/amtrack/sfdx-browserforce-plugin/src/plugins/passkey/schema.json",
+  "title": "Passkey (Built-in Authenticator) of the automation user",
+  "description": "Registers or deletes the single passkey of a DEDICATED automation user, so that it can clear Salesforce's forced passkey enrollment. Never point this at a user shared with a human: a second passkey cannot be added without an assertion against an existing one.",
+  "type": "object",
+  "properties": {
+    "registered": {
+      "title": "Whether a passkey we hold the credential for is registered",
+      "description": "true registers a passkey if the user has none, false deletes the registered passkey. 'Registered' means a passkey exists AND its credential is the one in credentialFile.",
+      "type": "boolean"
+    },
+    "credentialFile": {
+      "title": "Path to the file storing the passkey credential",
+      "description": "The exported credential contains the authenticator's PRIVATE KEY and is password-equivalent: keep it out of version control and treat it as a secret. It is only valid for one org (the relying party id is the org hostname) and dies on a sandbox refresh, so '<host>' in the path is replaced by the org hostname. Without this file the passkey cannot be recognized as ours later and can only be deleted using 'force'.",
+      "type": "string"
+    },
+    "force": {
+      "title": "Delete a passkey whose credential we do not hold",
+      "description": "By default Browserforce refuses to delete a passkey it cannot recognize as its own, because a human may have created it. Only set this for a dedicated automation user.",
+      "type": "boolean"
+    }
+  },
+  "required": ["registered"]
+}

--- a/src/plugins/passkey/virtual-authenticator.ts
+++ b/src/plugins/passkey/virtual-authenticator.ts
@@ -1,0 +1,82 @@
+import { type CDPSession, type Page } from 'playwright';
+
+/**
+ * The client side key material of a passkey (a WebAuthn Credential) as
+ * exported from / imported into a Virtual Authenticator over the Chrome
+ * DevTools Protocol. Contains the private key: password-equivalent.
+ */
+export type VirtualAuthenticatorCredential = {
+  credentialId: string;
+  isResidentCredential: boolean;
+  /** the Relying Party id, which is the org hostname (My Domain) */
+  rpId?: string;
+  /** the ECDSA P-256 private key in PKCS#8 format */
+  privateKey: string;
+  userHandle?: string;
+  signCount: number;
+  largeBlob?: string;
+  backupEligibility?: boolean;
+  backupState?: boolean;
+  userName?: string;
+  userDisplayName?: string;
+};
+
+// Salesforce requests attestation "direct" but does not verify the AAGUID, and
+// does not restrict the authenticator attachment (see poc/README.md).
+const VIRTUAL_AUTHENTICATOR_OPTIONS = {
+  protocol: 'ctap2',
+  transport: 'internal',
+  hasResidentKey: true,
+  hasUserVerification: true,
+  isUserVerified: true,
+  automaticPresenceSimulation: true,
+} as const;
+
+/**
+ * A software authenticator emulated over the Chrome DevTools Protocol, scoped
+ * to a single page (Chromium enables the virtual authenticator environment per
+ * frame tree, so it survives navigations of that page only).
+ *
+ * IMPORTANT: attach exactly ONE authenticator per page. A stray second (empty)
+ * authenticator intercepts navigator.credentials.get and fails it with
+ * NotAllowedError (see docs/adr/0002).
+ */
+export class VirtualAuthenticator {
+  private readonly cdpSession: CDPSession;
+  private readonly authenticatorId: string;
+
+  private constructor(cdpSession: CDPSession, authenticatorId: string) {
+    this.cdpSession = cdpSession;
+    this.authenticatorId = authenticatorId;
+  }
+
+  public static async attach(
+    page: Page,
+    credentials: VirtualAuthenticatorCredential[] = [],
+  ): Promise<VirtualAuthenticator> {
+    const cdpSession = await page.context().newCDPSession(page);
+    await cdpSession.send('WebAuthn.enable');
+    const { authenticatorId } = await cdpSession.send('WebAuthn.addVirtualAuthenticator', {
+      options: { ...VIRTUAL_AUTHENTICATOR_OPTIONS },
+    });
+    const authenticator = new VirtualAuthenticator(cdpSession, authenticatorId);
+    for (const credential of credentials) {
+      await authenticator.addCredential(credential);
+    }
+    return authenticator;
+  }
+
+  public async addCredential(credential: VirtualAuthenticatorCredential): Promise<void> {
+    await this.cdpSession.send('WebAuthn.addCredential', {
+      authenticatorId: this.authenticatorId,
+      credential,
+    });
+  }
+
+  public async getCredentials(): Promise<VirtualAuthenticatorCredential[]> {
+    const { credentials } = await this.cdpSession.send('WebAuthn.getCredentials', {
+      authenticatorId: this.authenticatorId,
+    });
+    return credentials;
+  }
+}

--- a/src/plugins/schema.json
+++ b/src/plugins/schema.json
@@ -7,6 +7,9 @@
   "properties": {
     "settings": {
       "properties": {
+        "passkey": {
+          "$ref": "./passkey/schema.json"
+        },
         "authProviders": {
           "$ref": "./auth-providers/schema.json"
         },

--- a/test/e2e-setup.ts
+++ b/test/e2e-setup.ts
@@ -2,6 +2,7 @@ import { Org } from '@salesforce/core';
 import { type Options } from 'p-retry';
 import { chromium } from 'playwright';
 import { Browserforce } from '../src/browserforce.js';
+import { isEnrollmentGateUrl } from '../src/pages/login.js';
 
 before('global setup', async () => {
   const org = await Org.create({});
@@ -10,7 +11,15 @@ before('global setup', async () => {
   await browserContext.tracing.group('global setup');
   const browserforce = new Browserforce(connection, browserContext, { retry: createRetryOptionsFromEnv() });
   global.browserforce = browserforce;
-  await browserforce.login();
+  // The passkey e2e spec needs the user to start without a passkey, which makes
+  // the login land on the enrollment gate. Tolerate it here so that spec can run.
+  const page = await browserforce.loginOnPage(await browserContext.newPage(), { tolerateEnrollmentGate: true });
+  if (isEnrollmentGateUrl(new URL(page.url()))) {
+    console.warn(
+      `WARNING: the login was intercepted by the passkey enrollment gate, because this user has no passkey.\nOnly the passkey e2e spec can run against this org.`,
+    );
+  }
+  await page.close();
   await browserContext.tracing.groupEnd();
 });
 


### PR DESCRIPTION
## Passkeys

Salesforce mandates a passkey for privileged users. A user without one is intercepted at login by a forced enrollment page, which breaks any browser automation for that user. 

The `passkey` setting clears that gate by registering a passkey using an emulated (software) authenticator:

```json
{
  "settings": {
    "passkey": {
      "registered": true,
      "credentialFile": "./sf-passkey-<host>.json"
    }
  }
}
```

`"registered": false` deletes it again. `<host>` in `credentialFile` is replaced by the org hostname, because a passkey is only valid for the org it was created for.

By registering a passkey during login, it's possible to perform the actions in the UI afterwards. The credentialFile is saved so it can be reused in another session. This has however not been verified, because SF does not seem to require the verification even in new sessions. But by removing the passkey afterwards, you will be prompted on next login to register one again.

The purpose with saving the credential file is so it can be saved to something like Azure Key Vault and be reused across CI pipelines if needed, or it can just be deleted from the org and the disk to have the registration process trigger again.

> [!WARNING]
>
> - Only point this at a **dedicated automation user**, never at one shared with a human. Adding a second passkey requires an assertion against an existing one, which the automation cannot do for a passkey it does not hold. Browserforce therefore refuses to touch a passkey whose credential it does not hold, unless `"force": true` is set.
> - `credentialFile` contains the authenticator's **private key** and is password-equivalent. Keep it out of version control and treat it as a secret.
> - This is **not** hardware-bound phishing-resistant MFA. It satisfies the enrollment gate; anyone who can read the credential file (or the org's sfdx auth) holds the factor. Say so before presenting it to an auditor.
> - Every registration and deletion is written to the `SetupAuditTrail`.

The `--passkey-credential` flag loads a saved credential into a virtual authenticator before the login of any subcommand, so that a passkey challenge (e.g. from an untrusted CI IP) could be answered. It is unverified best-effort: inert unless Salesforce actually challenges the passkey, and server side acceptance has not been confirmed.

This is a potential solution to #750